### PR TITLE
Use rgba(255,255,255,0) instead of transparent in -webkit-tap-highlight-color  

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -37,7 +37,7 @@ video {
 /*
  * 1. Add vertical scrollbar to <html> element
  *      Keeps page centred in all browsers regardless of content height
- * 2. Remove iOS tap highlight color to prevent entire container being highlighted
+ * 2. Remove Android and iOS tap highlight color to prevent entire container being highlighted
  *      www.yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/
  * 3. Remove iOS text size adjust without disabling user zoom
  *      www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/
@@ -45,7 +45,7 @@ video {
 
 html {
     overflow-y: scroll; /* 1 */
-    -webkit-tap-highlight-color: transparent; /* 2 */
+    -webkit-tap-highlight-color: rgba(255, 255, 255,0 ); /* 2 */
     -webkit-text-size-adjust: 100%; /* 3 */
     -ms-text-size-adjust: 100%;
 }


### PR DESCRIPTION
This fixes the annoying hilight on Android devices (and possibly others running webkit too). Works also in iOS, so the backwards compatibility is kept.
