### PR TITLE
In Chrome, the default style looked something like this:

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -437,3 +437,30 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+/* =============================================================================
+   HTML 5 
+   ========================================================================== */
+
+/* 
+ * Normalize the size of h1 elements for IE browsers of version less than 9.
+ */
+
+article article h1,
+article aside h1,
+article nav h1,
+article section h1,
+aside article h1,
+aside aside h1,
+aside nav h1,
+aside section h1,
+nav article h1,
+nav aside h1,
+nav nav h1,
+nav section h1,
+section article h1,
+section aside h1,
+section nav h1,
+section section h1 {
+  font-size: 1.17em;
+}


### PR DESCRIPTION
```
:-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) h1 {
    font-size: 1.17em;
    -webkit-margin-before: 1em;
    -webkit-margin-after: 1em;
}
```

IE 9 had the same font size. I could not find a good way to be as concise as the above example that works cross browser.

There may be other headers within the new semantic tags that should be normalized.
