### PR TITLE
Replaced dot in first line with dash

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,4 +1,4 @@
-/*! normalize.css 2011-08-31T22:02 UTC · http://github.com/necolas/normalize.css */
+/*! normalize.css 2011-08-31T22:02 UTC - http://github.com/necolas/normalize.css */
 
 /* =============================================================================
    HTML5 display definitions


### PR DESCRIPTION
Replaced dot in first line with dash since it throws an error if used in conjunction with Rails 3.1. asset pipeline asset compiler.

```
$ rake assets:precompile --trace
** Invoke assets:precompile (first_time)
** Execute assets:precompile
rake aborted!
Invalid US-ASCII character "\xC2"
```
