### PR TITLE
Extra space around Checkboxes and Radio Buttons in IE7

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -382,6 +382,7 @@ input[type="checkbox"],
 input[type="radio"] {
     box-sizing: border-box; /* 1 */
     padding: 0; /* 2 */
+    *width: 13px; *height: 13px;
 }
 
 /*


### PR DESCRIPTION
added fixed sizes for checkbox and radio button. this will remove extra space around them in IE7
