### PR TITLE
Add word-wrap:break-word to textarea in Opera

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -418,11 +418,13 @@ input::-moz-focus-inner {
 /*
  * 1. Removes default vertical scrollbar in IE6/7/8/9
  * 2. Improves readability and alignment in all browsers
+ * 3. Force new line for long character sequences in Opera
  */
 
 textarea {
     overflow: auto; /* 1 */
     vertical-align: top; /* 2 */
+    word-wrap:break-word; /* 3 */
 }
 
 


### PR DESCRIPTION
When typing long "words" or a sequence of characters in textareas in Opera a horizontal scroll appears when reaching the end of the line. In other browsers the text continues on a new line.

I therefore suggest that we add `word-wrap:break-word;` to `textarea` which resolves this issue in Opera.

The text continues on a new line in the following tested browsers:
IE6-9
Firefox 6
Google Chrome 14
Safari 5
