### PR TITLE
Prevents small affecting line-height in all browsers

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -207,15 +207,12 @@ q:after {
     content: none;
 }
 
-small {
-    font-size: 75%;
-}
-
 /*
- * Prevents sub and sup affecting line-height in all browsers
+ * Prevents small, sub and sup affecting line-height in all browsers
  * gist.github.com/413930
  */
 
+small,
 sub,
 sup {
     font-size: 75%;


### PR DESCRIPTION
It's just one pixel - but it effects the line height just like with sub and sup.

Fixed with this commit.
