### PR TITLE
IE6 support for button elements

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -356,10 +356,12 @@ input[type="submit"] {
 }
 
 /*
- * Corrects inner spacing of buttons displayed oddly in IE6
+ * 1. Improves usability and consistency of cursor style between image-type 'input' and others in IE6
+ * 2. Corrects inner spacing of buttons displayed oddly in IE6
  */
 * html button {
-    overflow: visible;
+    cursor: pointer; /* 1 */
+    overflow: visible; /* 2 */
 }
 
 /*


### PR DESCRIPTION
IE6 ignores the whole rule because of the attribute selectors.

``` css
button,
input[type="button"], 
input[type="reset"], 
input[type="submit"]
```

I did this fix to at least support button elements in IE6.
For input button support, an extra class is required. That's up to the user.
