### PR TITLE
Fixed unnecessary margins on nested lists

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -235,6 +235,11 @@ ol {
     padding: 0 0 0 40px;
 }
 
+li ul,
+li ol {
+   margin: 0;
+}
+
 dd {
     margin: 0 0 0 40px;
 }


### PR DESCRIPTION
Some browsers remove top and bottom margins by default which enhances readability of nested lists.
