### PR TITLE
Removes top margin on :first-child paragraphs, lists and headings.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -127,7 +127,7 @@ h1 {
 }
 
 /*
- * Remove uneccesary top margins on first-child content elements
+ * Remove unnecessary top margins on first-child content elements
  */
 
 p:first-child,


### PR DESCRIPTION
The top margin on these elements is good, but that little strip of whitespace along the top feels like it shouldn't be there. This works because usually you'll have your main content under a `<div>` or something, so the first one will lose it's top margin.

I copy and paste this snippet into my sites all the time and have had it work pretty well for me. If you don't like it that's fine, just an idea :)
