### PR TITLE
fix placeholder attribute in input field to behave according to spec.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -275,6 +275,7 @@
 
                 <p><label>Select field <select><option>Option 01</option><option>Option 02</option></select></label></p>
                 <p><label>Textarea <textarea cols="30" rows="5" >Textarea text</textarea></label></p>
+				<p><label>Textarea <textarea cols="30" rows="5" placeholder="Textarea placeholder text" ></textarea></label></p>
             </fieldset>
 
             <fieldset>
@@ -295,6 +296,7 @@
 
                 <p><label for="s">Select field</label> <select id="s"><option>Option 01</option><option>Option 02</option></select></p>
                 <p><label for="t">Textarea</label> <textarea id="t" cols="30" rows="5" >Textarea text</textarea></p>
+				<p><label for="twp">Textarea</label> <textarea id="twp" cols="30" rows="5" placeholder="Textarea placeholder text" ></textarea></p>
             </fieldset>
 
             <fieldset>

--- a/normalize.css
+++ b/normalize.css
@@ -482,7 +482,7 @@ input[type="search"]::-webkit-search-cancel-button {
 * Spec gist: User agents should present this hint to the user...when the element's...control is not focused.
 * You can see the discussion here: http://code.google.com/p/chromium/issues/detail?id=106714
 */
-input:focus::-webkit-input-placeholder {
+:focus::-webkit-input-placeholder {
   color: transparent;
 }
 


### PR DESCRIPTION
As you can see in my comments in normalize.css:

The placeholder attribute in Chrome does not work to spec.  This makes the text transparent on focus to work like Firefox, Safari, and the spec.

Spec gist: User agents should present this hint to the user...when the element's...control is not focused.

You can see the discussion here: http://code.google.com/p/chromium/issues/detail?id=106714
