### PR TITLE
Remove margins of nested lists.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -292,7 +292,6 @@ ul ol {
    margin: 0;
 }
 
-
 dd {
     margin: 0 0 0 40px;
 }


### PR DESCRIPTION
Nested lists by default shouldn't have margins, which is the case in all major browsers (even IE6).
