### PR TITLE
Update normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -95,6 +95,12 @@ body {
 /* =============================================================================
    Links
    ========================================================================== */
+   
+/* 
+ * Retains pointer hand on links without href attribute (e.g. for jQuery events)
+ */
+
+a {cursor:pointer;}
 
 /*
  * Addresses outline displayed oddly in Chrome


### PR DESCRIPTION
Small change, on ie6, the pointer cursor does not display on links without an href attribute. I use said elements when using jquery on links.
