### PR TITLE
hide webkit search-decoration and cancel-button in input[type="search"] ...

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -466,6 +466,7 @@ input[type="search"] {
 input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button {
     -webkit-appearance: none;
+    display: none;
 }
 
 /*


### PR DESCRIPTION
...elements. Safari was still showing these weird elements, even with -webkit-appearance: none. display:none must be used. I was having issues in Safari and found the solution here: http://geek.michaelgrace.org/2011/06/webkit-search-input-styling/
