### PR TITLE
Fix scaling in IE10 docked window mode 

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,5 +1,13 @@
 /*! normalize.css 2012-03-11T12:53 UTC - http://github.com/necolas/normalize.css */
 
+/*
+ * Corrects scaling in IE10 docked window mode
+ */
+
+@-ms-viewport {
+    width: device-width;
+}
+
 /* =============================================================================
    HTML5 display definitions
    ========================================================================== */


### PR DESCRIPTION
IE10 zooms the page out when docked window mode is used, making most sites unreadable. A CSS property tells it not to.

see: http://hammerspace.co.uk/2012/04/responsive-design-in-internet-explorer-10-windows-8
