### PR TITLE
Add padding to buttons in IE7 for consistency with other versions.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,4 +1,4 @@
-/*! normalize.css 2012-03-11T12:53 UTC - http://github.com/necolas/normalize.css */
+/*! normalize.css 2012-05-22T10:42 UTC - http://github.com/necolas/normalize.css */
 
 /* =============================================================================
    HTML5 display definitions
@@ -411,6 +411,7 @@ input {
  * 1. Improves usability and consistency of cursor style between image-type 'input' and others
  * 2. Corrects inability to style clickable 'input' types in iOS
  * 3. Removes inner spacing in IE7 without affecting normal text inputs
+ * 4. Add padding to buttons in IE7 for consistency with other versions
  *    Known issue: inner spacing remains in IE6
  */
 
@@ -421,6 +422,7 @@ input[type="submit"] {
     cursor: pointer; /* 1 */
     -webkit-appearance: button; /* 2 */
     *overflow: visible;  /* 3 */
+    *padding: 1px 8px; /* 4 */
 }
 
 /*


### PR DESCRIPTION
Because of the 'overflow:visible' declaration for buttons and inputs in IE 7, the default padding in those buttons is removed. This is very noticeable when compared to IE 8+. Adding the default padding in IE 8+ to IE 7 buttons and inputs makes the buttons look consistent with IE 8+.
