### PR TITLE
Normalizing the `text-transform` default value on select and button nodes.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -402,6 +402,16 @@ input {
 }
 
 /*
+ * Addresses default values only being set for `button` in Webkit, and only
+ * being set by IE and WebKit for `select`.
+ */
+
+ button,
+ select {
+    text-transform: none;
+ }
+
+/*
  * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
  *    and `video` controls.
  * 2. Corrects inability to style clickable `input` types in iOS.


### PR DESCRIPTION
I ran into this one the other day and thought it was a good fit for this project.  Certain browsers declare default `text-transform` values for `button` and `select` in their user agent stylesheets and certain browsers don't.

The easiest way to see this is comparing WebKit vs. Gecko vs. Trident with this fiddle - http://jsfiddle.net/tj_vantoll/dUjXB/11/.

I wrote up a more thorough explanation of what I've found on my blog - http://tjvantoll.com/2012/07/10/default-browser-handling-of-the-css-text-transform-property/.
