### PR TITLE
Update normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -318,6 +318,7 @@ nav ol {
 img {
     border: 0; /* 1 */
     -ms-interpolation-mode: bicubic; /* 2 */
+    display:inline-block 
 }
 
 /*


### PR DESCRIPTION
I suggest to add img{display:inline-block} to get width and height on firefox for 404 images.
