### PR TITLE
Removes Webkit outline on input and textarea on focus

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -486,6 +486,15 @@ textarea {
     vertical-align: top; /* 2 */
 }
 
+/*
+ * Removes Webkit outline on input and textarea on focus
+ */
+input, textarea {
+    outline: none;
+}
+
+
+
 /* ==========================================================================
    Tables
    ========================================================================== */


### PR DESCRIPTION
Just add a rule to remove unstandard "borders" on input and textarea focus (on webkit)
