### PR TITLE
Normalizing the default handling of the :invalid pseudoclass  

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -366,8 +366,8 @@ textarea {
  * 2. Removes default for IE 10.
  */
 :invalid {
-    box-shadow: none;
-    outline: none;
+    box-shadow: none; /* 1 */
+    outline: none; /* 2 */
 }
 
 /* ==========================================================================


### PR DESCRIPTION
By default Firefox places a red `box-shadow` and IE 10 places a red `outline` around `:invalid` fields.  You can see this by submitting this form in each browser - http://jsfiddle.net/tj_vantoll/mSGs4/.

WebKit and Presto do nothing with this behavior so the easiest way to get a consistent look is simply to simply reset the values.

I'm a bit torn about this because I do think that having the red `outline` / `box-shadow` makes for a more usable form, but I think having consistent behavior is more important.

Let me know what you think.
