### PR TITLE
Correct hr box-sizing in latest Firefox 

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -201,6 +201,14 @@ sub {
     bottom: -0.25em;
 }
 
+/*
+ * Addresses box-sizing set differently in Firefox.
+ */
+
+hr {
+    -moz-box-sizing: content-box;
+}
+
 /* ==========================================================================
    Embedded content
    ========================================================================== */


### PR DESCRIPTION
The box-sizing of the HR element is set to border-box in latest Firefox (15) while it is set to content-box in Chrome (22), Opera (12), Safari (5.1), IE9 and IE8.

You can easily test it with the HTML5 Boilerplate code:

hr {
    display: block;
    height: 1px;
    border: 0;
    border-top: 1px solid #ccc;
    margin: 1em 0;
    padding: 0;
}

Just add border-bottom: 1px solid #ccc; and you will see that there is an empty line between the borders in all browsers except Firefox.

I would also propose to set the height of the HR element in Boilerplate to 0 so it is possible to style it with two borders. If the height must remain 1px in Boilerplate it would be an alternative to set the box-sizing to border-box for all browsers in normalize.css
