### PR TITLE
Better Text Rendering

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -5,6 +5,18 @@
    ========================================================================== */
 
 /*
+ * 1. Improves font rendering in Webkit browsers and stops text flash when
+ *    transitioning/transforming
+ * 2. Initializes hardware acceleration on iOS and several other mobile browsers
+ */
+body {
+    opacity: .999999; /* 1 */
+    -webkit-transform: translate3d(0, 0, 0); /* 2 */
+    -moz-transform: translate3d(0, 0, 0); /* 2 */
+    transform: translate3d(0, 0, 0); /* 2 */
+}
+
+/*
  * Corrects `block` display not defined in IE 8/9.
  */
 


### PR DESCRIPTION
Applying `opacity: .999999` & `tranform: translate3d(0, 0, 0)`
to either `<body>` or `<html>` will improve font rendering and site
performance in a bunch of browsers by initializing hardware
acceleration (http://www.youtube.com/watch?v=IKl78ZgJzm4).

I'm not sure who to credit the `opacity .999999` trick but I
choose to use six 9's since in the inspector it rounds up to 1

The opacity trick has been demonstrated to fix a lot of things
other than font rendering, and oddly enough it actually improves
css speed when it's working with hardware acceleration.

Peace
