### PR TITLE
Add datalist element normalization

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -45,6 +45,14 @@ audio:not([controls]) {
 }
 
 /**
+ * Address styling not present in IE 7/8/9, Firefox 3, and Safari.
+ */
+
+datalist {
+   display: none;
+}
+
+/**
  * Address styling not present in IE 7/8/9, Firefox 3, and Safari 4.
  * Known issue: no IE 6 support.
  */


### PR DESCRIPTION
In the rendering, the datalist element represents nothing and it, along with its children, should be hidden.

According to [WHATWG 4.10.10 The datalist element spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#the-datalist-element).
