### PR TITLE
Add "main" to component.json as required by Bower

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
     "version": "2.0.1",
     "author": "Nicolas Gallagher",
     "homepage": "http://necolas.github.com/normalize.css/",
-    "styles": ["normalize.css"],
+    "main": ["normalize.css"],
     "repository": {
         "type": "git",
         "url": "https://github.com/necolas/normalize.css.git"


### PR DESCRIPTION
According to the docs on the Bower homepage ( https://github.com/twitter/bower#defining-a-package ), you need to use `name`, `version`, and `main` in the component.json file.

I'm not sure why (maybe Bower's docs changed?), but Normalize's component.json is using `name`, `version`, and **`styles`**.

The attached commit changes `styles` to `main`.
