### PR TITLE
Add <main> element

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -17,6 +17,7 @@ footer,
 header,
 hgroup,
 nav,
+main,
 section,
 summary {
     display: block;


### PR DESCRIPTION
Last month Editor's Draft of `<main>` element specification was published. It's good idea to include this element in "HTML5 display definitions" section. I suppose it will be used more and more often from now, so it's always good to have it there.

http://www.w3.org/TR/2012/WD-html-main-element-20121217/
