### PR TITLE
Position all elements relative by default

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -394,3 +394,28 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+
+/* ==========================================================================
+   Positioning
+   ========================================================================== */
+
+/**
+ * Position all elements relative by default.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary,
+div {
+    position: relative;
+}


### PR DESCRIPTION
At first I didn't think this belonged in normalize.css until I read
point 4 of the normalize.css readme (Improves usability with subtle
improvements), I believe this commit achieves that, as more of than not
when we position an element absolutely we want to position it relative
to its container, and not to the page itself. It's more economical with
our time to position the container static if we should need to position
this element to the page rather than its parent.
