### PR TITLE
[hidden] attribute should have high precedence

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -48,7 +48,7 @@ audio:not([controls]) {
  */
 
 [hidden] {
-    display: none;
+    display: none !important;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
the `[hidden]` attribute should take precedence over other `display` declarations, otherwise conflicting information could be presented to assistive technologies. It wouldn't make sense for a screen reader to ignore an element marked as "hidden" while it's clearly visible on the page.

If the element is to be shown, the `[hidden]` attribute should be removed, not overridden.
