### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "necolas/normalize.css",
+    "description": "A modern, HTML5-ready alternative to CSS resets.",
+    "type": "component",
+    "homepage": "http://necolas.github.com/normalize.css",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nicolas Gallagher",
+            "homepage": "http://nicolasgallagher.com"
+        }
+    ],
+    "support": {
+        "wiki": "https://github.com/necolas/normalize.css/wiki",
+        "issues": "https://github.com/necolas/normalize.css/issues",
+        "source": "https://github.com/necolas/normalize.css"
+    },
+    "require": {
+        "robloach/component-installer": "*"
+    },
+    "extra": {
+        "component": {
+            "styles": [
+                "normalize.css"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a package management system for PHP. This PR allows Normalize.css to be installed seamlessly into projects that use Composer. This is quite similar to how you can install Normalize.css using [Bower](http://twitter.github.io/bower/).

The following is an example of a _composer.json_ file that would download and install Normalize.css:

``` json
{
    "require": {
        "necolas/normalize.css": "*"
    },
    "minimum-stability": "dev"
}
```

The above is processed by running a composer install:

``` bash
$ curl -sS https://getcomposer.org/installer | php
$ composer.phar install
```
