### PR TITLE
Html background color prevents body background color/images from displaying full window #bug

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -66,18 +66,18 @@ audio:not([controls]) {
  */
 
 html {
-    /*background: #fff;*/ /* 1 */
-    color: #000; /* 2 */
     font-family: sans-serif; /* 3 */
     -ms-text-size-adjust: 100%; /* 4 */
     -webkit-text-size-adjust: 100%; /* 4 */
 }
 
 /**
- * Remove default margin.
+ * Remove default margin and system color scheme override.
  */
 
 body {
+    background: #fff; /* 1 */
+    color: #000; /* 2 */
     margin: 0;
 }
 


### PR DESCRIPTION
Issue described here: https://github.com/necolas/normalize.css/issues/188

Issue example at: http://jonathangrover.com/normalize-test/
Fixed issue at: http://jonathangrover.com/normalize-fix/

It was confusing one of my students when they applied a background color to their body and the html background was preventing it to display.
This issue is related to an issue specifically with HTML5 doctypes when declaring an html elements background property it interferes with the body elements background attributes. (See another example at: http://stackoverflow.com/questions/12125961/background-color-property-doesnt-work-correctly-with-html5-doctype )

This issue occurred for me on mac OSX 10.6.8 and 10.7.5 in Safari, Firefox, Opera, and Chrome.

To fix this I moved the background and color properties from the html element to the body element. This should still allow the background: #fff to override the system defaults because according to the W3C the html element will inherit its background and colors from the body. The nice thing about this change is that it is less confusing for beginners who can simply add background images and colors directly to the body which is most common. Also  it will work in all browsers (as-is there is potential for the body background not to work correctly as seen in my example).

You can contact me at hello@jonathangrover.com or @jongrover

Thanks for a great css reset/style guide.
