### PR TITLE
Remove cancel button in IE10.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -363,6 +363,15 @@ input[type="search"]::-webkit-search-decoration {
 }
 
 /**
+ * Remove cancel button in IE10.
+ */
+
+input[type="text"]::-ms-clear,
+input[type="search"]::-ms-clear {
+   display: none;
+}
+
+/**
  * Remove inner padding and border in Firefox 4+.
  */
 


### PR DESCRIPTION
Rule to remove the cancel button in IE10 in text and seach inputs.
Documentation: http://msdn.microsoft.com/en-us/library/windows/apps/hh465740.aspx
