### PR TITLE
Add LICENSE.md and README.md to ignore section of bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,8 @@
     "ignore": [
         "CHANGELOG.md",
         "CONTRIBUTING.md",
+        "LICENSE.md",
+        "README.md",
         "component.json",
         "test.html"
     ]


### PR DESCRIPTION
I presume all files except the bower.json and normalize.css files should be in the ignore section of bower.json.

Feel free to close this pull request if LICENSE.md and README.md are intentionally left out of "ignore".
