### PR TITLE
Remove the bottom margin of iframes

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -24,6 +24,13 @@ summary {
 }
 
 /**
+ * Removes the bottom margin of iframes
+ */
+iframe {
+    display: block;
+}
+
+/**
  * Correct `inline-block` display not defined in IE 8/9.
  */
 


### PR DESCRIPTION
Because iframes are inline, they have a strange bottom margin by default.

http://stackoverflow.com/questions/7290214/html-strange-space-between-iframe-elements
