### PR TITLE
Hide the `template` element in IE, Safari, and Firefox < 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 == HEAD
 
+* Hide the `template` element in IE, Safari, and Firefox < 22.
+
 == 1.1.2 (May 11, 2013)
 
 * Revert root `color` and `background` normalizations.

--- a/normalize.css
+++ b/normalize.css
@@ -46,11 +46,12 @@ audio:not([controls]) {
 }
 
 /**
- * Address styling not present in IE 7/8/9, Firefox 3, and Safari 4.
- * Known issue: no IE 6 support.
+ * Address `[hidden]` styling not present in IE 8/9.
+ * Hide the `template` element in IE, Safari, and Firefox < 22.
  */
 
-[hidden] {
+[hidden],
+template {
     display: none;
 }
 


### PR DESCRIPTION
Please see 77982e2 for the original commit.

This is for v1.
