### PR TITLE
Remove 'User Agent' padding in th, td tags.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -404,3 +404,8 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+th,
+td {
+    padding: 0;
+}


### PR DESCRIPTION
Removes the 1px padding inside table th and td tags that the browser User Agent adds.  (Firefox and IE8)

Issue #231 
