### PR TITLE
Update normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -18,6 +18,7 @@ header,
 hgroup,
 main,
 nav,
+progress,
 section,
 summary {
     display: block;


### PR DESCRIPTION
Correct `block` display not defined in IE 8/9 for <progress>.
