### PR TITLE
Correct `inline-block` display not defined in IE 8/9 for progress tag

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -29,6 +29,7 @@ summary {
 
 audio,
 canvas,
+progress,
 video {
     display: inline-block;
 }


### PR DESCRIPTION
Fix issue #253
