### PR TITLE
Set opacity to `1` for Mozilla Firefox 19+

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -339,6 +339,14 @@ html input[disabled] {
 }
 
 /**
+* 1. Opacity set to `1` in Mozilla Firefox 19+
+*/
+
+input::-moz-placeholder{
+    opacity: 1;
+}
+
+/**
  * 1. Address box sizing set to `content-box` in IE 8/9/10.
  * 2. Remove excess padding in IE 8/9/10.
  */

--- a/test.html
+++ b/test.html
@@ -271,6 +271,7 @@
             <fieldset>
                 <legend>Inputs as descendents of labels (form legend). This doubles up as a long legend that can test word wrapping.</legend>
                 <p><label>Text input <input type="text" value="default value that goes on and on without stopping or punctuation"></label></p>
+                <p><label>Text input with placeholder <input type="text" placeholder="Placeholder text"></label></p>
                 <p><label>Email input <input type="email"></label></p>
                 <p><label>Search input <input type="search"></label></p>
                 <p><label>Tel input <input type="tel"></label></p>


### PR DESCRIPTION
Base on this https://bugzilla.mozilla.org/show_bug.cgi?id=556145 mozilla firefox change the placeholder color to a color with opacity, that way when you try to add a different color to the placeholder you never get the correct placeholder color.
