### PR TITLE
Update link to Guardian's responsive site

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                     <a href="https://medium.com/">Medium</a>,
                     <a href="http://data.nasa.gov/">NASA</a>,
                     <a href="https://www.gov.uk/">GOV.UK</a>,
-                    <a href="http://m.guardian.co.uk/">Guardian</a>,
+                    <a href="http://www.theguardian.com/uk?view=mobile">Guardian</a>,
                     <a href="https://www.rdio.com/">Rdio</a>,
                     <a href="http://favstar.fm/">Favstar</a>,
                     <a href="http://informationarchitects.net/">iA</a>,


### PR DESCRIPTION
We performed a domain change last summer: http://www.theguardian.com/uk?view=mobile

![ ](http://s2.developerslife.ru/public/images/gifs/8f801b66-1192-4989-8618-4e61aaf560c1.gif)
