### PR TITLE
Remove the <hgroup> tag since it’s no longer supported, and due to the f...

### DIFF
--- a/test.html
+++ b/test.html
@@ -44,10 +44,8 @@
         </article>
 
         <header>
-            <hgroup>
                 <h1>Heading 1 (in hgroup)</h1>
                 <h2>Heading 2 (in hgroup)</h2>
-            </hgroup>
             <nav>
                 <ul>
                     <li><a href="#">navigation item #1</a></li>


### PR DESCRIPTION
...act that was a semantic tag, it is not replaced by any other tag.
