### PR TITLE
Remove intrinsic min-width of fieldset

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -264,6 +264,7 @@ fieldset {
     border: 1px solid #c0c0c0;
     margin: 0 2px;
     padding: 0.35em 0.625em 0.75em;
+    min-width: 0;
 }
 
 /**


### PR DESCRIPTION
At least firefox [1] and chrome [2] have a legacy/ intrinsic min-width
for the `fieldset` element. 
This removes it. The fix is especially useful on mobile.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=504622
[2] http://stackoverflow.com/questions/8084343/google-chrome-fieldset-overflow-bug
