### PR TITLE
Create consistent widths for textareas and inputs

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -267,6 +267,16 @@ fieldset {
 }
 
 /**
+ * Define consistent border and padding.
+ */
+
+input,
+textarea {
+    border: 1px solid #c0c0c0;
+    padding: 2px;
+}
+
+/**
  * 1. Correct `color` not being inherited in IE 8/9.
  * 2. Remove padding so people aren't caught out if they zero out fieldsets.
  */

--- a/test.html
+++ b/test.html
@@ -354,6 +354,12 @@
                 <div><button type="button">Button (button)</button></div>
                 <div><button type="submit">Submit (button)</button></div>
             </fieldset>
+            
+            <fieldset>
+                <legend>Consistent widths for textareas and inputs</legend>
+                <div><input style="width:200px;" type="text" value="text"></div>
+                <div><textarea style="width:200px;" rows="1">Textarea text</textarea></div>
+            </fieldset>
         </form>
 
     </body>


### PR DESCRIPTION
Chrome, Firefox, IE, and Opera have inconsistent borders and padding in regards to textarea and input elements.

This pull request adds a consistent border and padding to input & textarea elements.  This allows them to look similar across browsers and also have the same visual width if they are both set to the same width.

Chrome -
Input: 1x1 px padding and 2x2 px borders
Textarea: 2x2 px padding and 1x1 px borders

Firefox -
Input: 2x2 px padding and 1x1 px borders
Textarea: 2x2 px padding and 1x1 px borders

IE -
Input: 1x2 px padding and 1x1 px borders
Textarea: 2x2 px padding and 1x1 px borders

Opera -
Input: 0x1 px padding and 2x2px borders
Textarea: 2x2 px padding and 1x1 px borders

For more infomation see request:
https://github.com/necolas/normalize.css/issues/126
