### PR TITLE
Improved block display comment.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -24,7 +24,7 @@ body {
    ========================================================================== */
 
 /**
- * Correct `block` display not defined in IE 8/9.
+ * Correct `block` display not defined in IE 8/9/10/11.
  */
 
 article,


### PR DESCRIPTION
Hi there,

just a little improvement to the block display comment. IE11 is missing the User Agent Style for the main element (http://stackoverflow.com/questions/20094276/ie11-is-missing-user-agent-style-for-main-element-display-block). I think IE10 is also affected.

PS: Thanks for normalize.css.
