### PR TITLE
Setting inconsistency in borders set for the "input"

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -318,6 +318,7 @@ input::-moz-focus-inner {
 input {
   line-height: normal;
 }
+
 /**
  * Fixes different border set in Chrome for WIN
  */
@@ -325,6 +326,7 @@ input {
 input {
   border:1px solid #aaa;
 }
+
 /**
  * It's recommended that you don't attempt to style these elements.
  * Firefox's implementation doesn't respect box-sizing, padding, or width.


### PR DESCRIPTION
Please check the border setting differently in the Chrome stable version for win 7.!
