### PR TITLE
Revert "monospace, monospace" change accidentally made in 45cc401

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -226,7 +226,7 @@ code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
+  font-family: monospace, serif;
   font-size: 1em;
 }
 


### PR DESCRIPTION
I usually watch all the changes pretty closely in normalize.css.

It looks like during the code clean-up of 45cc401523c73a7ea48d433a269a7164059a4812, that the `code, kbd, pre, samp` ruleset was changed from `font-family: monospace, serif;` to `font-family: monospace, monospace;`.

I searched online and found that Eric Meyer tested the monospace, monospace option and it didn't work in his tests. http://meyerweb.com/eric/thoughts/2010/02/12/fixed-monospace-sizing/

For this pull request, I'm going to assume that the change was accidental. If it was done purposefully, can you explain the rationale for the change?

Thanks!
