### PR TITLE
Update comment above link active/hover rule.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -87,7 +87,7 @@ a {
 }
 
 /**
- * Improve readability when focused and also mouse hovered in all browsers.
+ * Improve readability when active or mouse hovered in all browsers.
  */
 
 a:active,


### PR DESCRIPTION
The comment above the `a:active, a:hover` ruleset mentions "focused" instead of "active".
