### PR TITLE
Move pre and code rules to "Text-level semantics" section.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -116,6 +116,18 @@ strong {
 }
 
 /**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/**
  * Address styling not present in Safari 5 and Chrome.
  */
 
@@ -140,6 +152,14 @@ h1 {
 mark {
   background: #ff0;
   color: #000;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
 }
 
 /**
@@ -208,26 +228,6 @@ hr {
   -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
-}
-
-/**
- * Contain overflow in all browsers.
- */
-
-pre {
-  overflow: auto;
-}
-
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
 }
 
 /* Forms


### PR DESCRIPTION
I like the new grouping of rulesets, but I couldn't figure out why the `code, kbd, pre, samp` and `pre` rulesets were in the "Grouping content" section. To me, they should be in the "Text-level semantics" section.
