### PR TITLE
Properly alphabetize fieldset in the "Forms" section.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -311,6 +311,16 @@ input::-moz-focus-inner {
 }
 
 /**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
  * Address Firefox 4+ setting `line-height` on `input` using `!important` in
  * the UA stylesheet.
  */
@@ -366,16 +376,6 @@ input[type="search"] {
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
-}
-
-/**
- * Define consistent border, margin, and padding.
- */
-
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
 }
 
 /**


### PR DESCRIPTION
Each section of normalize appears to have its rulesets listed in alphabetical order. However, the `fieldset` is mis-alphabetized after the `input` rules.
