### PR TITLE
removing border radius on form elements added by iOS Safari

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -245,6 +245,7 @@ samp {
  *    Known issue: affects color of disabled elements.
  * 2. Correct font properties not being inherited.
  * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ * 4. Removes border radius added by iOS Safari
  */
 
 button,
@@ -255,6 +256,7 @@ textarea {
   color: inherit; /* 1 */
   font: inherit; /* 2 */
   margin: 0; /* 3 */
+  border-radius: 0; /* 4 */
 }
 
 /**


### PR DESCRIPTION
I noticed on my iPhone that form elements have a border radius added to them and thought it would be useful in normalize.
