### PR TITLE
Placeholder

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -407,6 +407,22 @@ optgroup {
   font-weight: bold;
 }
 
+/**
+ * Inconsistent color for HTML5 placeholder text among the browsers.
+ * 1. Firefox 19+: There is a opacity value in the UA stylesheet.
+ */
+
+::-webkit-input-placeholder {
+	color: inherit;
+}
+::-moz-placeholder {
+	color: inherit;
+	opacity: 1; /* 1 */
+}
+:-ms-input-placeholder {
+	color: inherit;
+}
+
 /* Tables
    ========================================================================== */
 


### PR DESCRIPTION
I noticed that color of HTML5 placeholder text is not consistent among the browsers. Again in Firefox, there is a opacity of 0.54. I think this can be normalized.
