### PR TITLE
Remove highlight when tapping links in iOS

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -4,12 +4,14 @@
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.
+ * 3. Remove highlight when tapping links in iOS
  */
 
 html {
   font-family: sans-serif; /* 1 */
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
+  -webkit-tap-highlight-color: rgba(0,0,0,0); /* 3 */
 }
 
 /**


### PR DESCRIPTION
In Safari for iOS when you tap a link automatically is highlighted. I think it would be nice to remove this function to preserve style across different mobile browsers. [Apple Dev Reference](https://developer.apple.com/library/ios/documentation/appleapplications/reference/safariwebcontent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW1)

![Highlight reference image](https://developer.apple.com/library/ios/documentation/appleapplications/reference/safariwebcontent/Art/highlightelements.jpg)
