### PR TITLE
Update normalize.css, remove redundant monospace

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -228,7 +228,7 @@ code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
+  font-family: monospace;
   font-size: 1em;
 }
 


### PR DESCRIPTION
The font-family for these elements was previously `monospace, serif` and changed to `monospace, monospace` in 3fe0df0. The double `monospace` was likely redundant. If not, then maybe the reason for it should be documented?
