### PR TITLE
Added tt to code, kbd, pre…

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -227,7 +227,8 @@ pre {
 code,
 kbd,
 pre,
-samp {
+samp,
+tt{
   font-family: monospace, monospace;
   font-size: 1em;
 }


### PR DESCRIPTION
Normalise `<tt>` element to 1em.

Testcase: http://codepen.io/leevigraham/pen/ILAca

The `<tt>` is actually obsolete which make make this invalid. It is however outputted as part of the Sphinx-Doc doc generator which is used by quite a few OS projects. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt
