### PR TITLE
Just remove the background-color from links on IE 10

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -85,7 +85,7 @@ template {
  */
 
 a {
-  background: transparent;
+  background-color: transparent;
 }
 
 /**


### PR DESCRIPTION
I'm using some pretty brutal rules on all of my projects now

``` css
* {
  box-sizing: border-box;
  border-collapse: collapse;

  background-repeat: no-repeat;
  background-position: center center;
  background-size: cover;
}
```

And this `a { background: transparent }` is overriding some of them. I'm not sure it's a desired behavior, so scoping to `background-color` seems a better choice. Don't you think ?
