### PR TITLE
SCSS Version of normalize.css with non-compiling comments

### DIFF
--- a/normalize.scss
+++ b/normalize.scss
@@ -1,0 +1,355 @@
+/* ! begin normalize.css v3.0.1 | MIT License | git.io/normalize/ ! */
+//__ 
+// • 1. Set default font family to sans-serif.
+// • 2. Prevent iOS text size adjust after orientation change, without disabling user zoom.
+html {
+  font-family: sans-serif; //__ 1
+  -ms-text-size-adjust: 100%; //__ 2
+  -webkit-text-size-adjust: 100%; //__ 2
+}
+
+//__ 
+// • Remove default margin.
+body {
+  margin: 0;
+}
+
+// HTML5 display definitions
+//__ 
+// • Correct `block` display not defined for any HTML5 element in IE 8/9.
+// • Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
+// • Correct `block` display not defined for `main` in IE 11.
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary {
+  display: block;
+}
+
+//__ 
+// • 1. Correct `inline-block` display not defined in IE 8/9.
+// • 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; //__ 1
+  vertical-align: baseline; //__ 2
+}
+
+//__ 
+// • Prevent modern browsers from displaying `audio` without controls.
+// • Remove excess height in iOS 5 devices.
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+//__ 
+// • Address `[hidden]` styling not present in IE 8/9/10.
+// • Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+[hidden],
+template {
+  display: none;
+}
+
+// Links
+//__ 
+// • Remove the gray background color from active links in IE 10.
+a {
+  background: transparent;
+}
+
+//__ 
+// • Improve readability when focused and also mouse hovered in all browsers.
+a:active,
+a:hover {
+  outline: 0;
+}
+
+// Text-level semantics
+//__ 
+// • Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+//__ 
+// • Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+b,
+strong {
+  font-weight: bold;
+}
+
+//__ 
+// • Address styling not present in Safari and Chrome.
+dfn {
+  font-style: italic;
+}
+
+//__ 
+// • Address variable `h1` font-size and margin within `section` and `article`
+// • contexts in Firefox 4+, Safari, and Chrome.
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+//__ 
+// • Address styling not present in IE 8/9.
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+//__ 
+// • Address inconsistent and variable font size in all browsers.
+small {
+  font-size: 80%;
+}
+
+//__ 
+// • Prevent `sub` and `sup` affecting `line-height` in all browsers.
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+// Embedded content
+   
+//__ 
+// • Remove border when inside `a` element in IE 8/9/10.
+img {
+  border: 0;
+}
+
+//__ 
+// • Correct overflow not hidden in IE 9/10/11.
+svg:not(:root) {
+  overflow: hidden;
+}
+
+// Grouping content
+//__ 
+// • Address margin not present in IE 8/9 and Safari.
+figure {
+  margin: 1em 40px;
+}
+
+//__ 
+// • Address differences between Firefox and other browsers.
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+//__ 
+// • Contain overflow in all browsers.
+pre {
+  overflow: auto;
+}
+
+//__ 
+// • Address odd `em`-unit font size rendering in all browsers.
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+// Forms
+   
+//__ 
+// • Known limitation: by default, Chrome and Safari on OS X allow very limited
+// • styling of `select`, unless a `border` property is set.
+
+//__ 
+// • 1. Correct color not being inherited.
+// •    Known issue: affects color of disabled elements.
+// • 2. Correct font properties not being inherited.
+// • 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; //__ 1
+  font: inherit; //__ 2
+  margin: 0; //__ 3
+}
+
+//__ 
+// • Address `overflow` set to `hidden` in IE 8/9/10/11.
+
+button {
+  overflow: visible;
+}
+
+//__ 
+// • Address inconsistent `text-transform` inheritance for `button` and `select`.
+// • All other form control elements do not inherit `text-transform` values.
+// • Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+// • Correct `select` style inheritance in Firefox.
+
+button,
+select {
+  text-transform: none;
+}
+
+//__ 
+// • 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+// •    and `video` controls.
+// • 2. Correct inability to style clickable `input` types in iOS.
+// • 3. Improve usability and consistency of cursor style between image-type
+// •    `input` and others.
+
+button,
+html input[type="button"], //__ 1
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; //__ 2
+  cursor: pointer; //__ 3
+}
+
+//__ 
+// • Re-set default cursor for disabled elements.
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+//__ 
+// • Remove inner padding and border in Firefox 4+.
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+//__ 
+// • Address Firefox 4+ setting `line-height` on `input` using `!important` in
+// • the UA stylesheet.
+
+input {
+  line-height: normal;
+}
+
+//__ 
+// • It's recommended that you don't attempt to style these elements.
+// • Firefox's implementation doesn't respect box-sizing, padding, or width.
+// *
+// • 1. Address box sizing set to `content-box` in IE 8/9/10.
+// • 2. Remove excess padding in IE 8/9/10.
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; //__ 1
+  padding: 0; //__ 2
+}
+
+//__ 
+// • Fix the cursor style for Chrome's increment/decrement buttons. For certain
+// • `font-size` values of the `input`, it causes the cursor style of the
+// • decrement button to change from `default` to `text`.
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+//__ 
+// • 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+// • 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+// •    (include `-moz` to future-proof).
+
+input[type="search"] {
+  -webkit-appearance: textfield; //__ 1
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; //__ 2
+  box-sizing: content-box;
+}
+
+//__ 
+// • Remove inner padding and search cancel button in Safari and Chrome on OS X.
+// • Safari (but not Chrome) clips the cancel button when the search input has
+// • padding (and `textfield` appearance).
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+//__ 
+// • Define consistent border, margin, and padding.
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+//__ 
+// • 1. Correct `color` not being inherited in IE 8/9/10/11.
+// • 2. Remove padding so people aren't caught out if they zero out fieldsets.
+
+legend {
+  border: 0; //__ 1
+  padding: 0; //__ 2
+}
+
+//__ 
+// • Remove default vertical scrollbar in IE 8/9/10/11.
+
+textarea {
+  overflow: auto;
+}
+
+//__ 
+// • Don't inherit the `font-weight` (applied by a rule above).
+// • NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+
+optgroup {
+  font-weight: bold;
+}
+
+// Tables
+   
+//__ 
+// • Remove most spacing between table cells.
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+
+/* ! end normalize.css v3.0.1 | MIT License | git.io/normalize/ ! */


### PR DESCRIPTION
I modified normalize.css and converted to an scss format. Biggest change: replacing all comments `/* */` with `//` so that they won't compile with run through SASS or Compass.

I created an opening and closing comment that does print so that author still gets attribution in output *.css file 
