### PR TITLE
Normalize background color

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -4,12 +4,15 @@
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.
+ * 3. Set the background color to white for some obscure user-agents (like
+ *    Pocket when in night mode).
  */
 
 html {
   font-family: sans-serif; /* 1 */
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
+  background-color: #fff; /* 3 */
 }
 
 /**


### PR DESCRIPTION
Most browsers set white as the default background, but not all. When reading in "night mode", [Pocket](http://pocket.co) defaults to having a dark background for web pages. This renders some pages unreadable. This aims to fix that for sites using normalize.css.

This PR doesn't update version numbers or the changelog, but it can!
