### PR TITLE
Font-weight:bolder for fonts with multiple weights

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -110,11 +110,18 @@ abbr[title] {
 
 /**
  * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ * 1. Take font-weigh value from parent element
+ * 2. Set font-weight bolder that parent 
  */
 
 b,
 strong {
-  font-weight: bold;
+  font-weight: inherit; /* 1 */
+}
+
+b,
+strong {
+  font-weight: bolder; /* 2 */
 }
 
 /**


### PR DESCRIPTION
Improvement for fonts that have multiple weights.  
If some block, for example header, is bold and has `strong` inside we can make `strong` bolder if font has additional weights.
 
```html
<h1>Header with <strong>nested <strong>strong</strong> inside</strong></h1>
```

Check this [demo](http://cssdeck.com/labs/x20utix0).