### PR TITLE
Fixes font-family fallback for monospace elements

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -228,7 +228,7 @@ code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
+  font-family: monospace, serif;
   font-size: 1em;
 }
 


### PR DESCRIPTION
Reverts change introduced by error in 3fe0df0fe
