### PR TITLE
`-webkit-appearance: textfield;` not work in iOS7

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -353,7 +353,7 @@ input[type="number"]::-webkit-outer-spin-button {
  */
 
 input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
+  -webkit-appearance: none; /* 1 */
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box; /* 2 */
   box-sizing: content-box;


### PR DESCRIPTION
change `textfield` to `none` make it works on all devices