### PR TITLE
Removed default margin of menu element

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -16,7 +16,7 @@ html {
  * Remove default margin.
  */
 
-body {
+body, menu {
   margin: 0;
 }
 


### PR DESCRIPTION
Default margin of menu element was 16 pixels on webkit browsers.
Now it's 0 points.
