### PR TITLE
Using normalize-css instead of normalize.css for bower.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ normalizing.
 
 * [npm](http://npmjs.org/): `npm install --save normalize.css`
 * [Component(1)](https://github.com/component/component/): `component install necolas/normalize.css`
-* [Bower](http://bower.io/): `bower install --save normalize.css`
+* [Bower](http://bower.io/): `bower install --save normalize-css`
 * [Download](http://necolas.github.io/normalize.css/latest/normalize.css).
 
 No other styles should come before Normalize.css.


### PR DESCRIPTION
Changed README bower package name to avoid problems with including normalize.css in build dependencies and match bower.json description.

`normalize.css`

```
Warning: Unable to read "bower_components/normalize.css" file (Error code: EISDIR). Use --force to continue.
```

`normalize-css`

```
Done, without errors.
```
