### PR TITLE
Use Bower package `normalize.css` consistently

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <div class="txt-large">
           <pre><code><a href="https://www.npmjs.org/package/normalize.css/">npm</a> install normalize.css</code></pre>
           <pre><code><a href="http://component.io/">component</a> install necolas/normalize.css</code></pre>
-          <pre><code><a href="http://bower.io/">bower</a> install normalize-css</code></pre>
+          <pre><code><a href="http://bower.io/">bower</a> install normalize.css</code></pre>
         </div>
 
         <div class="share-bar">


### PR DESCRIPTION
As a follow-up of #373 this PR updates the bower install command to use the `normalize.css` package consistently.
