### PR TITLE
Normalize `hr` overflow

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -205,13 +205,15 @@ figure {
 }
 
 /**
- * Address differences between Firefox and other browsers.
+ * 1. Address differences between Firefox and other browsers.
+ * 2. Address `overflow` set to `hidden` in IE 8/9/10/11.
  */
 
 hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0;
+  -moz-box-sizing: content-box; /* 1 */
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /**


### PR DESCRIPTION
As you can put pseudo elements on hr elements the overflow property is now something that should be 'normalized'.

This property in IE7 was set to visible which is the same as what chrome and firefox currently do.

However IE 8, 9, 10 set overflow to hidden.

Usecase: http://codepen.io/jnowland/pen/JoYKNP
