### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "normalize.css",
   "version": "3.0.2",
   "description": "Normalize.css as a node packaged module",
+  "main": "normalize.css",
   "style": "normalize.css",
   "files": [
     "normalize.css"


### PR DESCRIPTION
This is especially useful when normalize.css is bundled with webpack, which resolves import statements like node.