### PR TITLE
remove unnecessary vendor prefixes

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -209,7 +209,6 @@ figure {
  */
 
 hr {
-  -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
@@ -356,8 +355,6 @@ input[type="number"]::-webkit-outer-spin-button {
 
 input[type="search"] {
   -webkit-appearance: textfield; /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box; /* 2 */
   box-sizing: content-box;
 }
 


### PR DESCRIPTION
according to CanIUse you do not need vendor prefixes for `box-sizing` any more.
See: http://caniuse.com/#search=box-sizing