### PR TITLE
remove tap highlight

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,6 +1,14 @@
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 
 /**
+ * Get rid of grey tap highlight on mobile devices
+*/
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/**
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.


### PR DESCRIPTION
Remove grey tap highlight on mobile devices.

![](http://www.luster.io/images/tap_highlight_small.png)

See: http://www.luster.io/blog/9-29-14-mobile-web-checklist.html
