### PR TITLE
This comment seems to be causing confusion

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -91,7 +91,7 @@ a {
 }
 
 /**
- * Improve readability when focused and also mouse hovered in all browsers.
+ * Improve readability when active focused and also mouse hovered in all browsers.
  */
 
 a:active,


### PR DESCRIPTION
Just got a notification from this old issue: https://github.com/necolas/normalize.css/issues/357

It seems the comment confuses the reader to think what is changed is the `:focus` pseudo-selector when actually it's the active focused state of the element (or just the "active" state).