### PR TITLE
Set default box-sizing to border-box

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,6 +1,16 @@
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 
 /**
+ * Set default box-sizing to border-box
+ */
+
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/**
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.


### PR DESCRIPTION
If you make a responsive design the container is wider than 100%.
```css
.container {
  max-width: 100%; 
  padding: 20px;
}
```

This fixes the problem.
```css
* {
  -webkit-box-sizing: border-box;
  -moz-box-sizing: border-box;
  box-sizing: border-box;
}
```
