### PR TITLE
Fix normalize.css URL

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,4 +1,4 @@
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/*! normalize.css v3.0.2 | MIT License | github.com/necolas/normalize.css */
 
 /**
  * 1. Set default font family to sans-serif.


### PR DESCRIPTION
Currently the link `git.io/normalize` is broken.