### PR TITLE
Replace duplicate monospace, monospace property with monospace, serif

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -230,7 +230,7 @@ code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
+  font-family: monospace, serif;
   font-size: 1em;
 }
 


### PR DESCRIPTION
serif was incorrectly replaced with a second monospace property in commit 3fe0df0