### PR TITLE
scaling HTML element to window size

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -8,6 +8,8 @@
 
 html {
   font-family: sans-serif; /* 1 */
+	height: 100%;
+	width: 100%;
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }


### PR DESCRIPTION
In common browsers `html` may not completely fill the viewport unless otherwise specified. Specifically  `html` will become smaller than the viewport if the viewport is longer than it is wide. Normally this is not noticeable, but it becomes an issue when binding a background image to `html` without explicitly stating `height` and `width`.

```css
html {
  background: url( 'http://upload.wikimedia.org/wikipedia/commons/b/b0/Altare_afasta-se_terra_sol_lua.jpg' );
  background-size: cover;
  height: 100%;
  width: 100%;
}
```