### PR TITLE
Fix double lines for abbr element

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -109,6 +109,7 @@ a:hover {
 
 abbr[title] {
   border-bottom: 1px dotted;
+  text-decoration: none;
 }
 
 /**


### PR DESCRIPTION
> The Firefox user agent stylesheet has been updated to use the CSS3 [text-decoration](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) property for the [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) and [`<acronym>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/acronym) elements. Specifically, border-block-end: dotted 1px has been replaced with text-decoration: dotted underline. If you are styling one of those elements, you may want to make sure that your own style is not conflicting with the UA stylesheet. Note that Google Chrome is still using [border-bottom](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) instead of text-decoration, so you still have to use both properties to style those as intended.

[Default style of `<abbr>`/`<acronym>` has been changed - Site Compatibility for Firefox 40 - Mozilla | MDN](https://developer.mozilla.org/en/Firefox/Releases/40/Site_Compatibility#Default_style_of_%3Cabbr%3E.2F%3Cacronym%3E_has_been_changed)
### screenshot

![2015-05-16 13 33 57](https://cloud.githubusercontent.com/assets/12539/7664730/644c3094-fbd0-11e4-95f8-9f3b6bbc0b14.png)