### PR TITLE
More specific rule for removing border of an <img> inside an <a>

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -183,7 +183,7 @@ sub {
  */
 
 img {
-  border: 0;
+  border-width: 0;
 }
 
 /**


### PR DESCRIPTION
Fixes this use case:

    .someimg {
        border-width: 2px;
        border-color: green;
    }