### PR TITLE
Use underline dotted for abbr[title] if supported

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -111,6 +111,13 @@ abbr[title] {
   border-bottom: 1px dotted;
 }
 
+@supports (text-decoration: underline dotted) {
+  abbr[title] {
+    border-bottom: inherit;
+    text-decoration: underline dotted;
+  }
+}
+
 /**
  * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
  */


### PR DESCRIPTION
This changes to use `text-decoration: underline dotted` if supported for `abbr[title]` to be compatible with Firefox 40+.