### PR TITLE
Deprecate <hgroup>

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,4 +1,4 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css v3.1.0 | MIT License | github.com/necolas/normalize.css */
 
 /**
  * 1. Set default font family to sans-serif.
@@ -37,7 +37,7 @@ figcaption,
 figure,
 footer,
 header,
-hgroup,
+hgroup, /* Deprecated. To be removed in 4x */
 main,
 menu,
 nav,


### PR DESCRIPTION
Deprecates `<hgroup>` and bumps minor release
Schedules removal for next major release

Resolves #472