### PR TITLE
Remove explicit box-sizing for input[type="search"]

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -348,13 +348,11 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 /**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ * Address `appearance` set to `searchfield` in Safari and Chrome.
  */
 
 input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  box-sizing: content-box; /* 2 */
+  -webkit-appearance: textfield;
 }
 
 /**

--- a/test.html
+++ b/test.html
@@ -429,12 +429,6 @@
   <div class="Test-run">
     <input type="search" style="border:1px solid #ADD8E6; padding:10px; width:200px;">
   </div>
-  <h3 class="Test-it">should have a <code>content-box</code> box model</h3>
-  <div class="Test-run">
-    <div style="background:red; display:inline-block; height:62px; width:242px;">
-      <input type="search" style="border:1px solid #ADD8E6; height:20px; padding:20px; width:200px;">
-    </div>
-  </div>
   <h3 class="Test-it">should not have a cancel button in Safari or Chrome</h3>
   <div class="Test-run">
     <input type="search" value="search">


### PR DESCRIPTION
This normalizes the CSS to what the suggested default browser CSS should be, which is now implemented in IE11, Edge, Blink, WebKit and Gecko (for the latter, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=28784)

References https://github.com/twbs/bootstrap/issues/17379

Closes https://github.com/necolas/normalize.css/issues/471