### PR TITLE
Disabled element color inheritance

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -252,10 +252,8 @@ samp {
  */
 
 /**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ * 1. Correct font properties not being inherited.
+ * 2. Address margins set differently in Firefox 4+, Safari, and Chrome.
  */
 
 button,
@@ -263,9 +261,8 @@ input,
 optgroup,
 select,
 textarea {
-  color: inherit; /* 1 */
-  font: inherit; /* 2 */
-  margin: 0; /* 3 */
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**

--- a/test.html
+++ b/test.html
@@ -258,18 +258,6 @@
   </div>
 
   <h2 class="Test-describe"><code>button</code>, <code>input</code>, <code>optgroup</code>, <code>select</code>, <code>textarea</code></h2>
-  <h3 class="Test-it">should inherit <code>color</code> from ancestor</h3>
-  <div class="Test-run" style="color:#ADD8E6;">
-    <button>button</button><br>
-    <input value="input"><br>
-    <select style="border:1px solid #999;">
-      <optgroup label="optgroup">
-        <option>option</option>
-      </optgroup>
-      <option>option</option>
-    </select><br>
-    <textarea>textarea</textarea>
-  </div>
   <h3 class="Test-it">should inherit <code>font</code> from ancestor</h3>
   <div class="Test-run" style="font:bold italic 20px/1 serif;">
     <button>button</button><br>


### PR DESCRIPTION
As issues #349 and #339 explain, color inheritance applied to form elements creates some possible usability issues in certain scenarios (see http://codepen.io/anon/pen/FyhsL), and causes disabled form elements to appear as though they are enabled.

This removes the `color: inherit;` declaration and subsequent test to alleviate those issues.