### PR TITLE
Specify browsers for displaying `audio` without controls issue

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -59,8 +59,7 @@ video {
 }
 
 /**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
+ * Prevent displaying `audio` without controls in Mobile Safari 4/5/6/7.
  */
 
 audio:not([controls]) {


### PR DESCRIPTION
I've checked issue with `<audio>` without controls in all browsers available at http://crossbrowsertesting.com and find out that this issue take place only in Mobile Safari 4—7.

This is final codepen I've using for checking the bug: http://codepen.io/hudochenkov/pen/mVzpzL.

This is results with iOS (other browsers I've not included here, because they don't have issues):

[Screenshots](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/zdd8e3b5120ca708a264) for: 

```css
audio:not([controls]) {
	background: red;
}
```

[Screenshots](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/z82aaf7a774911d37ae7) for: 

```css
audio:not([controls]) {
	background: red;
	display: none;
}
```

[Screenshots](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/zb67456e16539eef9ece) for: 

```css
audio:not([controls]) {
	background: red;
	height: 0;
}
```

[Screenshots](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/z67755d72996156021ef) for: 

```css
audio:not([controls]) {
	background: red;
	display: none;
	height: 0;
}
```

References:

- Issue about `display: none` for this case #10 8ae3231cdbc86476b36050547a341ebcbc3cce4b
- Commit with adding `height: 0` 664a7a760e85a66f49f38c28a28681962afc69a5

