### PR TITLE
Remove `sudo: false` from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - stable


### PR DESCRIPTION
Since this repository was not recognized by Travis before 2015-01-01, there is no need to include `sudo: false` as that is now the default.

--

From https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure:

> The default behavior, when no sudo usage is detected in any customizable build phases, depends on the date when the repository is first recognized by Travis CI:

> * For repos we recognize before 2015-01-01, linux builds are sent to our standard infrastructure.
> * For repos we recognize on or after 2015-01-01, linux builds are sent to our container-based infrastructure "