### PR TITLE
Add Bower install details

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Additional detail and explanation of the esoteric parts of normalize.css.
 
 The `font-family: monospace, monospace` hack fixes the inheritance and scaling
 of font-size for preformatted text. The duplication of `monospace` is
-intentional.  [Source](http://en.wikipedia.org/wiki/User:Davidgothberg/Test59).
+intentional. [Source](http://en.wikipedia.org/wiki/User:Davidgothberg/Test59).
 
 #### `sub, sup`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ normalizing.
 ## Install
 
 * [npm](http://npmjs.org/): `npm install --save normalize.css`
+* [Bower](http://bower.io/): `bower install --save
+  https://github.com/necolas/normalize.css.git`
 * [cdnjs](https://cdnjs.com/libraries/normalize)
 * [Download](http://necolas.github.io/normalize.css/latest/normalize.css).
 


### PR DESCRIPTION
Since Bower **explicit support** was removed on 8cfa3e765e0cb55c174657e412430424a9fee97a many people complained about this.

I think that by clearly indicating the way to install normalize.css using Bower will help to reduce the number of comments/open-issues about that, and of course, help those that don't know how to install an unregistered package.

*This closes #527*