### PR TITLE
Mark opinionated styles

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,7 +1,7 @@
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 
 /**
- * 1. Set default font family to sans-serif.
+ * 1. Set default font family to sans-serif (opinionated).
  * 2. Prevent iOS and IE text size adjust after device orientation change,
  *    without disabling user zoom.
  */
@@ -13,7 +13,7 @@ html {
 }
 
 /**
- * Remove default margin.
+ * Remove default margin (opinionated).
  */
 
 body {


### PR DESCRIPTION
The `font-family: sans-serif` in the `html` [[1](https://github.com/necolas/normalize.css/blob/3.0.3/test.html#L89)] and `margin: 0` in the `body` [[2](https://github.com/necolas/normalize.css/blob/3.0.3/test.html#L95)] are opinionated declarations, thus marked as such.

*This closes #517 and #518.*