### PR TITLE
Use explicit `outline-width` property instead of `outline`

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -90,12 +90,12 @@ a {
 
 /**
  * Improve readability of focused elements when they are also in an
- * active/hover state.
+ * active/hover state (opinionated).
  */
 
 a:active,
 a:hover {
-  outline: 0;
+  outline-width: 0;
 }
 
 /* Text-level semantics


### PR DESCRIPTION
By using `outline-width` we are explicit in our intention.

Also as this is an [opinionated style](https://github.com/necolas/normalize.css/blob/3.0.3/test.html#L153), it's now marked as such.

*This closes #524.*