### PR TITLE
Use inherit to fix legend color

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -397,12 +397,12 @@ fieldset {
 }
 
 /**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 1. Correct `color` not being inherited from fieldset in IE 8/9/10/11.
  * 2. Remove padding so people aren't caught out if they zero out fieldsets.
  */
 
 legend {
-  border: 0; /* 1 */
+  color: inherit; /* 1 */
   padding: 0; /* 2 */
 }
 


### PR DESCRIPTION
Use inherit to fix legend color and clarify that the fix applies to `<legend>` within `<fieldset>`.

This closes #363.