### PR TITLE
Update the dfn support message

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -130,7 +130,7 @@ strong {
 }
 
 /**
- * Address styling not present in Safari and Chrome.
+ * Address styling not present in Android < 4.4.
  */
 
 dfn {


### PR DESCRIPTION
**Chrome 16+**, **Edge 12+**, **Firefox 4+**, **Internet Explorer 6+**, **Opera 12.12+**, and **Safari 6+**. Only **Safari ≤ 5.1** is missing the style, which has not been in the supported browser stack of normalize.css v3.

Resolves #522