### PR TITLE
Remove unnecessary input line-height

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -334,15 +334,6 @@ input:-moz-focusring {
 }
 
 /**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
-
-input {
-  line-height: normal;
-}
-
-/**
  * It's recommended that you don't attempt to style these elements.
  * Firefox's implementation doesn't respect box-sizing, padding, or width.
  *

--- a/test.html
+++ b/test.html
@@ -375,12 +375,6 @@
     <p><input type="submit" value="input (submit)"></p>
   </div>
 
-  <h2 class="Test-describe"><code>input</code></h2>
-  <h3 class="Test-it">should not inherit <code>line-height</code></h3>
-  <div class="Test-run" style="line-height:50px">
-    <input value="input (text)">
-  </div>
-
   <h2 class="Test-describe"><code>input[type="checkbox"]</code>, <code>input[type="radio"]</code></h2>
   <h3 class="Test-it">should have a <code>border-box</code> box model</h3>
   <div class="Test-run Test-run--highlightEl" id="radio-box-model">


### PR DESCRIPTION
The `line-height` issue was resolved in Firefox 30, so this normalization may be dropped.

Resolves #377