### PR TITLE
Only normalize border-style on img

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -188,11 +188,11 @@ sub {
    ========================================================================== */
 
 /**
- * Remove border when inside `a` element in IE 8/9/10.
+ * Correct border-style given when inside `a` element in IE 8/9/10.
  */
 
 img {
-  border: 0;
+  border-style: none;
 }
 
 /**


### PR DESCRIPTION
Correct `border-style` given when inside `a` element in IE 8/9/10. See http://s.codepen.io/jonneal/debug/274c26a11e945ee932aa1f32512d48e6