### PR TITLE
Remove opinionated pre overflow

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -227,14 +227,6 @@ hr {
 }
 
 /**
- * Contain overflow in all browsers.
- */
-
-pre {
-  overflow: auto;
-}
-
-/**
  * 1. Correct inheritance and scaling of font-size for preformatted text.
  * 2. Address odd `em`-unit font size rendering in all browsers.
  */

--- a/test.html
+++ b/test.html
@@ -241,12 +241,6 @@
     <hr style="height:2px; border:solid #ADD8E6; border-width:2px 0;">
   </div>
 
-  <h2 class="Test-describe"><code>pre</code></h2>
-  <h3 class="Test-it">should trigger a scrollbar when too wide for its container</h3>
-  <div class="Test-run" style="max-width:300px; outline:1px solid #ADD8E6;">
-    <pre>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et me.</pre>
-  </div>
-
   <h2 class="Test-describe"><code>code</code>, <code>kbd</code>, <code>pre</code>, <code>samp</code></h2>
   <h3 class="Test-it">should render <code>em</code>-unit preformatted text at the same absolute size as normal text</h3>
   <div class="Test-run">


### PR DESCRIPTION
This removes the opinionated view that `pre` should contain its overflow.

Not necessary to merge unless there is more consensus.

Resolves #313