### PR TITLE
Remove overflow from select and update multiple overflow

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -271,12 +271,10 @@ optgroup {
 /**
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
- * 2. Show the overflow in Edge, Firefox, and IE.
  */
 
 button,
-input, /* 1 */
-select { /* 2 */
+input { /* 1 */
   overflow: visible;
 }
 


### PR DESCRIPTION
While the consistent `overflow` for `select` is `visible`, updating this property has no effect in any browser, but instead creates an inappropriately visible overflow for `select[multiple]`.

Resolves #562