### PR TITLE
Limit Firefox focus normalization to buttons

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -306,8 +306,10 @@ html [type="button"], /* 1 */
  */
 
 button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
   padding: 0;
 }
 
@@ -316,7 +318,9 @@ input::-moz-focus-inner {
  */
 
 button:-moz-focusring,
-input:-moz-focusring {
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 


### PR DESCRIPTION
Spacing does not need to be normalized for all `input` elements in
Firefox, only `button` and `[type="button"]` elements. These
normalizations were changing the default focus appearance of `input`
elements.

Resolves #549