### PR TITLE
Correct the text style of placeholders in Chrome, Edge, and Safari

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -393,3 +393,12 @@ textarea {
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}


### PR DESCRIPTION
Normalizes placeholder styles in Edge, Chrome, and Safari with Firefox.

Resolves #550