### PR TITLE
Remove gaps in links underline in iOS 8+ and Safari 8+

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -85,11 +85,13 @@ template, /* 1 */
    ========================================================================== */
 
 /**
- * Remove the gray background on active links in IE 10.
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
  */
 
 a {
-  background-color: transparent;
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
 }
 
 /**


### PR DESCRIPTION
Remove gaps in links underline in iOS 8+ and Safari 8+

This gaps presented in Safari and iOS only. They were added in Safari 8 and iOS 8 but CrossBrowserTesting show them even in Safari 6.

[CodePen without fix](http://codepen.io/hudochenkov/pen/RaxqNW) and [results](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/z894d678ffb8d28e7e2b).

![screen shot 2016-04-08 at 21 33 08](https://cloud.githubusercontent.com/assets/654597/14394080/1200d122-fdd3-11e5-8f3b-aeddf496c187.png)

[CodePen with fix](http://codepen.io/hudochenkov/pen/groQbM) and [results](https://app.crossbrowsertesting.com/public/i1769107ade2a10c/screenshots/z5cba15df917b55d4a30).

![screen shot 2016-04-08 at 21 33 10](https://cloud.githubusercontent.com/assets/654597/14394088/16bcd6a2-fdd3-11e5-9640-2eabe538e058.png)