### PR TITLE
Normalize file select buttons

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -291,7 +291,7 @@ select { /* 1 */
 /**
  * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
  *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
  */
 
 button,
@@ -403,4 +403,14 @@ textarea {
 ::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Chrome and Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }


### PR DESCRIPTION
> In the same way you are setting -webkit-appearance:button in line 299, i think you should do the same for the "select file" button present in file fields, in order to keep a uniform aspect between all fields in Safari:

Resolves #570