### PR TITLE
Correct the outline of search inputs in Chrome and Safari

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -381,11 +381,13 @@ textarea {
 }
 
 /**
- * Correct the odd appearance of search inputs in Chrome and Safari.
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
  */
 
 [type="search"] {
-  -webkit-appearance: textfield;
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**


### PR DESCRIPTION
After modifying search input with -webkit-appearance: textfield, the
focus outline is remaining with `outline-offset: 0`, but should be
`-2px` like other textfield inputs.

Resolves #547