### PR TITLE
Add role="button" to fix common iOS Safari bug

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -417,3 +417,11 @@ textarea {
   -webkit-appearance: button; /* 1 */
   font: inherit; /* 2 */
 }
+
+/**
+ * Allow elements with role=button to be pressed in Mobile Safari
+ * See: https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
+ */
+[role="button"] {
+  cursor: pointer;
+}


### PR DESCRIPTION
Just came across this little bug on a project, and figured it was something that could be helpful to others.