### PR TITLE
Normalize line heights for all headings

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -155,6 +155,20 @@ h1 {
 }
 
 /**
+ * Correct the line-height for all headings in Chrome mobile, Firefox,
+ * iOS Safari, Microsoft Edge and IE.
+ */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  line-height: 1.15;
+}
+
+/**
  * Add the correct background and color in IE 9-.
  */
 


### PR DESCRIPTION
Line heights are different between almost any browser out there for all heading tags, the majority of them apply a `1.15` to `line-height` property. For more insight check out the issue #593 

This is ready for review, @jonathantneal