### PR TITLE
Simplify headings normalization comment

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -155,8 +155,7 @@ h1 {
 }
 
 /**
- * Correct the line-height for all headings in Chrome mobile, Firefox,
- * iOS Safari, Microsoft Edge and IE.
+ * Correct the line height for headings in all browsers.
  */
 
 h1,

--- a/normalize.css
+++ b/normalize.css
@@ -155,7 +155,7 @@ h1 {
 }
 
 /**
- * Correct the line height for headings in all browsers.
+ * Correct the line height in all browsers.
  */
 
 h1,


### PR DESCRIPTION
The results for computed `line-height` in #593 were virtually different in all tested browsers, and since [such browsers are the ones we support](https://github.com/necolas/normalize.css#browser-support), I don't see the need to have a *complex* comment naming all of them. Also, having the "headings" reference is redundant, since by looking at the selectors is clear what we are targeting.

I know this is kinda silly, but it's important to keep comments short and to the point. 😉 