### PR TITLE
Remove `placeholder` normalization

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -403,15 +403,6 @@ textarea {
 }
 
 /**
- * Correct the text style of placeholders in Chrome, Edge, and Safari.
- */
-
-::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-/**
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.
  */


### PR DESCRIPTION
We can not safely normalize the `placeholder` without introducing a specific color —which would be very opinionated—, or without modifying the `opacity` —which would prevent the placeholder from being shown in Edge under certain conditions [due to a bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/3901363/).

*Context*: this was originally discussed on #550 and then added on #571. The decision to remove it was made on #580.

*Notes*: (a) I didn't modify the `test.html` file since I couldn't find a test for this. (b) I didn't add a note to the README as @jonathantneal suggested since as we no longer include this, it would be weird to add it to a section with the "additional detail and explanation of the esoteric parts of normalize.css." tagline —please, feel free to add it if you deem it necessary.

---

This closes #580.