### PR TITLE
Change latest it v4.2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Normalize.css: Make browsers render all elements more consistently.</title>
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="4.1.1/normalize.css">
+    <link rel="stylesheet" href="4.2.0/normalize.css">
     <link rel="stylesheet" href="main.css">
     <link rel="icon" href="favicon.ico">
   </head>
@@ -23,13 +23,13 @@
 
         <div class="cta-option">
           <a class="btn-download"
-             href="https://necolas.github.io/normalize.css/4.1.1/normalize.css">
+             href="https://necolas.github.io/normalize.css/4.2.0/normalize.css">
             <strong>Download</strong>
-            <span class="version">v4.1.1</span>
+            <span class="version">v4.2.0</span>
           </a>
           <div class="txt-small txt-mute">Chrome, Firefox, Opera, Safari 6+, IE 8+</div>
           <a class="txt-small txt-mute"
-             href="https://github.com/necolas/normalize.css/blob/4.1.1/CHANGELOG.md">See the CHANGELOG</a>
+             href="https://github.com/necolas/normalize.css/blob/4.2.0/CHANGELOG.md">See the CHANGELOG</a>
         </div>
 
         <div class="txt-large">


### PR DESCRIPTION
Noticed the website isn't pointing to the latest normalize.css version, just simply changes the hardtext & links.