### PR TITLE
Update normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -3,7 +3,7 @@
 /**
  * 1. Change the default font family in all browsers (opinionated).
  * 2. Correct the line height in all browsers.
- * 3. Prevent adjustments of font size after orientation changes in IE and iOS.
+ * 3. Prevent adjustments of font size after orientation changes in IE on Windows Phone and on iOS.
  */
 
 /* Document


### PR DESCRIPTION
Clarification that this rule applies to IE's mobile variant. Interestingly, we'll be able to remove "-ms-text-size-adjust" soon, as Windows Phone 8.1+ supports "-webkit-text-size-adjust" as an alias.

Documentation: https://msdn.microsoft.com/en-us/library/dn793579(v=vs.85).aspx