### PR TITLE
Place the document heading above the html element's comment.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,14 +1,14 @@
 /*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
 
+/* Document
+   ========================================================================== */
+
 /**
  * 1. Change the default font family in all browsers (opinionated).
  * 2. Correct the line height in all browsers.
  * 3. Prevent adjustments of font size after orientation changes in
  *    IE on Windows Phone and in iOS.
  */
-
-/* Document
-   ========================================================================== */
 
 html {
   font-family: sans-serif; /* 1 */


### PR DESCRIPTION
The section heading comment always appears above the individual comments for rulesets in that section.

Except for the new "Document" heading.

This PR fixes that.
