### PR TITLE
add pointer-events: none for svg:not(:root)

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -234,11 +234,13 @@ img {
 }
 
 /**
- * Hide the overflow in IE.
+ * 1. Hide the overflow in IE.
+ * 2. Prevent JavaScrpit Bug in Firefox when pointing on SVGs.
  */
 
 svg:not(:root) {
-  overflow: hidden;
+  overflow: hidden; /* 1 */
+  pointer-events: none; /* 2 */
 }
 
 /* Forms


### PR DESCRIPTION
In Firefox inline SVGs causes JavaScripts Bugs when hovering with the cursor. Setting the pointer-events to none is the workaround for that.

https://css-tricks.com/links-inline-svg-staying-target-events/