### PR TITLE
Fix repository's language classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+normalize.css linguist-vendored=false


### PR DESCRIPTION
Small fix to correct this repository's [language breakdown graph](https://github.com/necolas/normalize.css/search?l=html).

Since Normalize.css is [purposefully excluded](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml#L73) from language stats on GitHub, a `.gitattributes` file is needed to include it in the languages breakdown. Currently, the codebase is marked as 100% HTML.

More info on the `linguist-vendored` attribute [here](https://github.com/github/linguist#using-gitattributes).