### PR TITLE
Fix Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ See https://necolas.github.io/normalize.css/latest/normalize.css
 * iOS Safari (last two)
 * Opera (last two)
 * Safari 6+
-* [Normalize.css v1 provides legacy browser support](https://github.com/necolas/normalize.css/tree/v1) (IE 6+, Safari 4+),
-but is no longer actively developed.
+* _[Normalize.css v1 provides legacy browser support](https://github.com/necolas/normalize.css/tree/v1) (IE 6+, Safari 4+), but is no longer actively developed._
+
 
 
 ## Extended details and known issues

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ See https://necolas.github.io/normalize.css/latest/normalize.css
 * iOS Safari (last two)
 * Opera (last two)
 * Safari 6+
-* [*Normalize.css v1 provides legacy browser support*](https://github.com/necolas/normalize.css/tree/v1) *(IE 6+, Safari 4+),
-but is no longer actively developed.*
+* [Normalize.css v1 provides legacy browser support](https://github.com/necolas/normalize.css/tree/v1) (IE 6+, Safari 4+),
+but is no longer actively developed.
 
 
 ## Extended details and known issues

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ See https://necolas.github.io/normalize.css/latest/normalize.css
 * iOS Safari (last two)
 * Opera (last two)
 * Safari 6+
-
-*[Normalize.css v1 provides legacy browser support]
-(https://github.com/necolas/normalize.css/tree/v1) (IE 6+, Safari 4+),
+* [*Normalize.css v1 provides legacy browser support*](https://github.com/necolas/normalize.css/tree/v1) *(IE 6+, Safari 4+),
 but is no longer actively developed.*
 
 


### PR DESCRIPTION
I think the list misses one. 

**Changed**
``` markdown
## Browser support

* Chrome (last two)
* Edge (last two)
* Firefox (last two)
* Firefox ESR
* Internet Explorer 8+
* iOS Safari (last two)
* Opera (last two)
* Safari 6+

*[Normalize.css v1 provides legacy browser support]
(https://github.com/necolas/normalize.css/tree/v1) (IE 6+, Safari 4+),
but is no longer actively developed.*
```
**into**
``` markdown
## Browser support

* Chrome (last two)
* Edge (last two)
* Firefox (last two)
* Firefox ESR
* Internet Explorer 8+
* iOS Safari (last two)
* Opera (last two)
* Safari 6+
* [*Normalize.css v1 provides legacy browser support*](https://github.com/necolas/normalize.css/tree/v1) *(IE 6+, Safari 4+), but is no longer actively developed.*
```

(weird, the preview doesn't show the italic properly? It looks normal on the markdown preview in Atom.)

![screenshot markdown](https://cloud.githubusercontent.com/assets/23235841/24416817/4fa02e72-13e6-11e7-9695-d12668cdd482.png)
