### PR TITLE
Stop test.html from skewing language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 normalize.css linguist-vendored=false
+test.html linguist-vendored


### PR DESCRIPTION
I really should've paid more attention before submitting #660...

This PR finishes off what #660 should've done by excluding [`test.html`](https://github.com/necolas/normalize.css/blob/master/test.html) from the repository's language breakdown. It's common practice in many GitHub repos to mark test files with the [`linguist-documentation`](https://github.com/github/linguist/blob/master/lib/linguist/documentation.yml) attribute.

This is identical to [`linguist-vendored`](https://github.com/github/linguist#using-gitattributes) in that it stops marked files from skewing language stats... the key difference being that "documentation" files are included in diffs on GitHub, whereas vendored files aren't. Test-related files are the sort of thing that you don't want bloating language stats, but don't want hidden in diffs, either.

I know this isn't a *huge* issue, but if I'm gonna contribute a menial fix, I may as well do it right.

Here's the output of running `linguist` in the updated repository:

~~~
λ Normalize.css: linguist --breakdown .
100.00% CSS

CSS:
normalize.css

λ Normalize.css (linguist-fix-part-II)
~~~

Whereas before, it was this:

~~~
λ Normalize.css: linguist --breakdown .
65.83%  HTML
34.17%  CSS

CSS:
normalize.css

HTML:
test.html
~~~