### PR TITLE
Fieldset padding in firefox

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -293,6 +293,14 @@ button:-moz-focusring,
 }
 
 /**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
  * 1. Correct the text wrapping in Edge and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
  * 3. Remove the padding so developers are not caught out when they zero out


### PR DESCRIPTION
v6 has removed the opinionated styling for the `fieldset` element.
One of the removed rules was the padding, and I noticed that this introduced a little inconsistency between firefox and other browsers.
In my test, I saw consistent padding in chrome and IE. But a slightly different padding in Firefox.

Firefox
![image](https://cloud.githubusercontent.com/assets/2431842/25544714/701e3e82-2c64-11e7-9c51-ee2a119433ef.png)

Chrome
![image](https://cloud.githubusercontent.com/assets/2431842/25544746/8eb11e3c-2c64-11e7-9eab-ca21599695b1.png)
