### PR TITLE
Update normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -27,7 +27,7 @@ body {
 }
 
 /**
- * Add the correct display in IE 9-.
+ * Add the correct display in IE 8-.
  */
 
 article,
@@ -53,7 +53,7 @@ h1 {
    ========================================================================== */
 
 /**
- * Add the correct display in IE 9-.
+ * Add the correct display in IE 8-.
  * 1. Add the correct display in IE.
  */
 


### PR DESCRIPTION
Update comment to reflect that certain semantic elements are supported in IE 9. According to the [Internet Explorer 9 Guide for Developers](https://msdn.microsoft.com/en-us/ie/hh410106#_HTML5_Semantic_Elements), "_By default, the elements are now styled as specified in the HTML5 specification._"