### PR TITLE
[refs #00680] Reduce Google Fonts to one stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">
     <title>Normalize.css: Make browsers render all elements more consistently.</title>
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700|Open+Sans" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700|Open+Sans">
     <link rel="stylesheet" href="7.0.0/normalize.css">
     <link rel="stylesheet" href="main.css">
     <link rel="icon" href="favicon.ico">

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">
     <title>Normalize.css: Make browsers render all elements more consistently.</title>
-    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:700' rel='stylesheet' type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700|Open+Sans" rel="stylesheet">
     <link rel="stylesheet" href="7.0.0/normalize.css">
     <link rel="stylesheet" href="main.css">
     <link rel="icon" href="favicon.ico">


### PR DESCRIPTION
We can actually concatenate Google Fonts stylesheets, so I’ve done that
just to save us a critical request. This change only affects the
Normalize.css website, and not the Normalize.css project itself.