### PR TITLE
Restore gaps in links underline in iOS 8+ and Safari 8+

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -96,13 +96,11 @@ pre {
    ========================================================================== */
 
 /**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ * Remove the gray background on active links in IE 10.
  */
 
 a {
-  background-color: transparent; /* 1 */
-  -webkit-text-decoration-skip: objects; /* 2 */
+  background-color: transparent;
 }
 
 /**


### PR DESCRIPTION
#573 introduced the change. I propose to revert it, because:

1. It breaks iOS and macOS platform conventions: underlines are always drawn with “ink” style in native text views.
2. It’s a step back for web typography. Apple intentionally set the browser default to “ink” to make underlined text more readable.
3. The lack of this rule doesn’t affect other browsers, but its presence is harmful.
