### PR TITLE
Remove button border-radius in Chrome 62+ on macOS.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -272,6 +272,7 @@ select { /* 1 */
  * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
  *    controls in Android 4.
  * 2. Correct the inability to style clickable types in iOS and Safari.
+ * 3. Remove the border-radius in Chrome 62+ on macOS.
  */
 
 button,
@@ -279,6 +280,7 @@ html [type="button"], /* 1 */
 [type="reset"],
 [type="submit"] {
   -webkit-appearance: button; /* 2 */
+  border-radius: 0; /* 3 */
 }
 
 /**

--- a/test.html
+++ b/test.html
@@ -340,6 +340,14 @@
     <p><input type="reset" value="input (reset)"></p>
     <p><input type="submit" value="input (submit)"></p>
   </div>
+  <h3 class="Test-it">should not have <code>border-radius</code></h3>
+  <div class="Test-run">
+    <p><button>button</button></p>
+    <p><input type="button" value="input (button)"></p>
+    <p><input type="file" value="input (file)"></p>
+    <p><input type="reset" value="input (reset)"></p>
+    <p><input type="submit" value="input (submit)"></p>
+  </div>
 
   <h2 class="Test-describe">disabled <code>button</code> and <code>input</code></h2>
   <h3 class="Test-it">should have <code>default</code> cursor style</h3>


### PR DESCRIPTION
Chrome 62 buttons have been restyled to resemble macOS buttons:
https://www.chromestatus.com/features/5743649186906112

Other browser vendors haven’t signalled interest.

This leads to cross-browser inconsistencies in existing UIs.

This patch matches developer expectations of buttons not having border-radius set.