### PR TITLE
Add support for Eyeglass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+_normalize.scss

--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,15 +6,26 @@
   "style": "normalize.css",
   "files": [
     "LICENSE.md",
-    "normalize.css"
+    "normalize.css",
+    "eyeglass-exports.js",
+    "to-sass.js"
   ],
+  "eyeglass": {
+    "needs": "^1.0.0",
+    "exports": "eyeglass-exports.js",
+    "name": "normalize"
+  },
   "devDependencies": {
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0"
   },
   "scripts": {
-    "test": "stylelint normalize.css"
+    "test": "stylelint normalize.css",
+    "postinstall": "node ./to-sass.js"
   },
+  "keywords": [
+    "eyeglass-module"
+  ],
   "repository": "necolas/normalize.css",
   "license": "MIT",
   "bugs": "https://github.com/necolas/normalize.css/issues",

--- a/to-sass.js
+++ b/to-sass.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+const pkg = require('./package.json');
+
+// Output file paths
+var input = path.join(__dirname, pkg.main);
+var output = path.join(__dirname, '_' + path.basename(pkg.main, '.css') + '.scss');
+
+// Clean up Sass file if it's already there
+try {
+  fs.statSync(output);
+  fs.unlink(output);
+} catch(e) {
+  // It's OK if this errors, it means the file doesn't exist
+}
+
+// Cpoy input file to output file
+fs.writeFileSync(output, fs.readFileSync(input));


### PR DESCRIPTION
#638 was closed by saying "This could have a PR for it…", so I made a PR for it!

Quick explanation of what's happening:
- Add `eyeglass` fields to `package.json`
- Add `keyword` field to `package.json` and include the `eyeglass-module` keyword
- Update the `files` field in `package.json` to include the requisite `eyeglass-exports.js` file and the `to-sass.js` file (more on that in a moment)
- Add the `eyeglass-exports.js` file to tell Eyeglass where the files are stored
- Add `to-sass.js` file to convert `normalize.css` in to `_normalize.scss` after NPM install
- Add `_normalize.scss` to git ignore

Let me talk through `to-sass.js` because it's likely the most controversial of the additions. Sass cannot import raw CSS files, like what is currently distributed. As such, in order to have full compatibility with Eyeglass as expected for Sass authors, we need a Sass file. This is simple enough, change the `.css` extension to `.scss` and it can be imported (I also rename it to a Sass partial so it doesn't compile its own file, by prepending `_` to the file name). This could be a 1-liner with `cp normalize.css _normalize.scss`, but then `postintall` will fail on terminals that don't have a Bash-compatible `cp` function available. So, I needed to write a tiny file to A) delete `_normalize.scss` if it's already there and B) replace it with a clean copy based off of `normalize.css` making sure it's up-to-date. All of this is done with native Node libraries that are available back to version `0.12` of Node, meaning this should work basically everywhere that Node works, and absolutely every version of Node that is not [End of Life'd](https://github.com/nodejs/LTS)

I have tested installing and using Normalize from my branch in a project I already have set up. Presuming Eyeglass is already set up, using it in a Sass file after running `npm install normalize.css --save-dev` is `@import 'normalize'`.

---

Resolves #638