### PR TITLE
Add alternative CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bower install --save normalize-css
 
 **CDN**
 
-See https://cdnjs.com/libraries/normalize
+See https://cdnjs.com/libraries/normalize or https://www.jsdelivr.com/package/npm/normalize.css
 
 **Download**
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/normalize.css) to your readme as an alternative to cdnjs. jsDelivr is the fastest opensource CDN available and built specifically for production usage.