### PR TITLE
Remove the font-size test on html tag

### DIFF
--- a/test.html
+++ b/test.html
@@ -86,10 +86,6 @@
   <h1 class="Test-title"><a href="https://github.com/necolas/normalize.css">Normalize.css</a>: UI tests</h1>
 
   <h2 class="Test-describe"><code>html</code></h2>
-  <h3 class="Test-it">should have sans-serif font family (opinionated)</h3>
-  <div class="Test-run">
-    abcdefghijklmnopqrstuvwxyz
-  </div>
   <h3 class="Test-it">should have a line height of 1.15</h3>
   <div class="Test-run">
     abcdefghijklmnopqrstuvwxyz


### PR DESCRIPTION
Remove test: "should have sans-serif font family" in html section.
The font-size declaration in html tag [was removed](https://github.com/necolas/normalize.css/commit/b5f0e9d79a997952f0d68f55c12ec3b76dd65882#diff-bb3dde41d97f19be8ab7b4780a915d5eL14) and this test fails.

<img src="https://user-images.githubusercontent.com/3452011/31752395-0c2fbfec-b461-11e7-8ecd-c3edfcdaf998.png" width="450">