### PR TITLE
Remove Obsoleted Android 4.0 Code

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -269,16 +269,14 @@ select { /* 1 */
 }
 
 /**
- * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
- *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS and Safari.
+ * Correct the inability to style clickable types in iOS and Safari.
  */
 
 button,
-html [type="button"], /* 1 */
+[type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button; /* 2 */
+  -webkit-appearance: button;
 }
 
 /**


### PR DESCRIPTION
A super simple, one line change to the specificity of a button rule, removing an old, no longer needed workaround. 

This issue is in regards to the current line 278:
`html [type="button"], /* 1 */`
with the note:
`1. Prevent a WebKit bug where (2) destroys native audio and video controls in Android 4.`

This pull request returns the line to its original form of just: `[type="button"]` as it was intended to be. The issue itself has been obsoleted by Google: https://issuetracker.google.com/issues/36950539 More recent Android updates have resolved the bug.

This bug affected Android 4.0 from 2011. This browser version is outside of Normalize's documented Browser Support. Besides being beyond 2 versions of the browser version in the past, it is 6 whole OS versions behind the current version of Android. (And will be 7 next month). This version of the OS is no longer supported by even Google.