### PR TITLE
Remove the mention of Firefox, because it is not true now

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -400,7 +400,7 @@ textarea {
 
 /*
  * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
+ * 1. Add the correct display in Edge, IE.
  */
 
 details, /* 1 */


### PR DESCRIPTION
The "display" property is set to "block" by default