### PR TITLE
form elements inherit line height from ancestor

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -156,7 +156,7 @@ select,
 textarea {
   font-family: inherit; /* 1 */
   font-size: 100%; /* 1 */
-  line-height: 1.15; /* 1 */
+  line-height: inherit; /* 1 */
   margin: 0; /* 2 */
 }
 


### PR DESCRIPTION
I think it is more practical if the form elements inherit the line height instead of set it fix to 1.15. So if you change the line height of your root or any ancestor element, it will apply to your form elements.