### PR TITLE
Set a uniform dotted border on abbr in all browsers

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -70,14 +70,12 @@ a {
 }
 
 /**
- * 1. Remove the bottom border in Chrome 57-
- * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ * Set a dotted border in all browsers
  */
 
 abbr[title] {
-  border-bottom: none; /* 1 */
-  text-decoration: underline; /* 2 */
-  text-decoration: underline dotted; /* 2 */
+  border-bottom: 1px dotted currentColor;
+  text-decoration: none;
 }
 
 /**


### PR DESCRIPTION
The current solution is to have no border, a dotted underline, and a solid underline as fall back. This gives a non uniform solution between some browsers that still can't render dotted underlines.  

The reason for the current fix (as far as i have found) is because of the font Meiryo, not playing nicely with borders, as mentioned in a bugzilla report [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1157083), and in a pull request [here](https://github.com/necolas/normalize.css/pull/451).  
But this issue seams to have been solved since Firefox v40 as mentioned in the same [bugzilla report](https://bugzilla.mozilla.org/show_bug.cgi?id=1157083), and the earliest version that is qualified for the current ESR rotation is v52.  

Furthermore, the first version that was qualified for ESR is v10, and the global usage of v10 to v40 (where the bug was fixed) is 0.12% as seen [here](https://caniuse.com/usage-table).

My solution to this is.  
```CSS
abbr[title] {
  border-bottom: 1px dotted currentColor;
  text-decoration: none;
}
```  

While i agree that using a border, might not be the most elegant solution. This at least gives a uniform look.