### PR TITLE
Only Safari still needs this fix

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -266,7 +266,7 @@ textarea {
 }
 
 /**
- * Correct the cursor style of increment and decrement buttons in Chrome.
+ * Correct the cursor style of increment and decrement buttons in Safari.
  */
 
 [type="number"]::-webkit-inner-spin-button,


### PR DESCRIPTION
The cursor style issue was fixed in Chrome/Blink circa 2014, see https://bugs.chromium.org/p/chromium/issues/detail?id=337668.

However, the issue still persists in Safari/WebKit (tested and confirmed still exists in Safari 11.1).

WebKit bug tracker: https://bugs.webkit.org/show_bug.cgi?id=137269

Test case: https://bug-137269-attachments.webkit.org/attachment.cgi?id=252499