### PR TITLE
inherit line-height for form elements

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -156,7 +156,7 @@ select,
 textarea {
   font-family: inherit; /* 1 */
   font-size: 100%; /* 1 */
-  line-height: 1.15; /* 1 */
+  line-height: inherit; /* 1 */
   margin: 0; /* 2 */
 }
 


### PR DESCRIPTION
`line-height` is already set to `1.15` on `html`, so we can `inherit` the value, plus if `line-height` is overridden it will be cascaded.
