### PR TITLE
Remove the default apparence of select on all browsers

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -181,6 +181,15 @@ select { /* 1 */
 }
 
 /**
+ * Remove the default apparence of select on all browsers
+ */
+select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+/**
  * Correct the inability to style clickable types in iOS and Safari.
  */
 


### PR DESCRIPTION
Avoid select' styles issues if you're develop on Windows or OSX.