### PR TITLE
Add JavaScript build that exports normalize.css as string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ See https://necolas.github.io/normalize.css/latest/normalize.css
 * Safari 8+
 * Opera
 
+## JavaScript Usage
+
+You could also use `normalize.css` in your CSS-in-JS workflow.
+
+```javascript
+const normalizeCss = require('normalize.css/javascript');
+
+// example with injectGlobal from styled-components or emotion
+injectGlobal`
+  ${normalizeCss}
+`
+```
 
 ## Extended details and known issues
 

--- a/javascript.js
+++ b/javascript.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/normalize.css.js')

--- a/package.json
+++ b/package.json
@@ -5,15 +5,19 @@
   "main": "normalize.css",
   "style": "normalize.css",
   "files": [
+    "dist",
     "LICENSE.md",
-    "normalize.css"
+    "normalize.css",
+    "javascript.js"
   ],
   "devDependencies": {
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0"
   },
   "scripts": {
-    "test": "stylelint normalize.css"
+    "build": "node scripts/generateJs",
+    "test": "stylelint normalize.css",
+    "prepare": "npm run build"
   },
   "repository": "necolas/normalize.css",
   "license": "MIT",

--- a/scripts/generateJs.js
+++ b/scripts/generateJs.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const input = path.resolve(__dirname, '../normalize.css');
+const outputDir = path.resolve(__dirname, '../dist/');
+const output = path.resolve(outputDir, './normalize.css.js');
+
+let normalizeCss = fs.readFileSync(input, 'utf-8');
+normalizeCss = normalizeCss.replace(/\`/g, '\\`');
+
+const content = `module.exports = \`${normalizeCss}\``;
+
+if (!fs.existsSync(outputDir)){
+  fs.mkdirSync(outputDir);
+}
+
+fs.writeFileSync(output, content);


### PR DESCRIPTION
Many times when we want to include normalize.css in our CSS-in-JS workflow, we end up having to copy paste the content and maintain our own _fork_ of normalize.css, which essentially just normalize.css as string. Maintenance and upgrade can be quite a hassle.

Examples of normalize.css forks for CSS-in-JS:
* [typography-normalize](https://github.com/KyleAMathews/typography.js/blob/master/packages/typography-normalize/src/index.js) - which is still running v4.1.1
* [styped-normalize](https://github.com/sergeysova/styled-normalize)

This PR introduces additional JavaScript build to read and export content of `normalize.css` as string.

Example usage:
```javascript
const normalizeCss = require('normalize.css/javascript');

// example with injectGlobal from styled-components or emotion
injectGlobal`
  ${normalizeCss}
`
```