### PR TITLE
border-bottom: 0 instead of none

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -75,7 +75,7 @@ a {
  */
 
 abbr[title] {
-  border-bottom: none; /* 1 */
+  border-bottom: 0; /* 1 */
   text-decoration: underline; /* 2 */
   text-decoration: underline dotted; /* 2 */
 }


### PR DESCRIPTION
I guess it's somewhat subjective, but some folks prefers the `0` over `none`. Take it or leave it.