### PR TITLE
Add html5 display-role reset for main element

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -339,3 +339,11 @@ template {
 [hidden] {
   display: none;
 }
+
+/**
+ * Add the correct display in IE 11 (html5 display-role reset).
+ */
+
+main {
+  display: block;
+}


### PR DESCRIPTION
Old versions of IE once required a bunch of html5 elements display to be set to block. The browsers that required this are possibly out of scope, however, since the `main` element was added later, a reset is still required for this element in IE11. See: https://github.com/necolas/normalize.css/issues/727