### PR TITLE
Unify box-sizing

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -4,6 +4,14 @@
    ========================================================================== */
 
 /**
+ * Unify the box sizing to include borders.
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+/**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */


### PR DESCRIPTION
The `box-sizing` property has different defaults in different browsers, so this should be unified. The border should be included by default, so the normalized value should be `border-box`.