### PR TITLE
Maded line-height bigger

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -9,7 +9,7 @@
  */
 
 html {
-  line-height: 1.15; /* 1 */
+  line-height: 1.4; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }
 


### PR DESCRIPTION
Added a bigger line-height helps allways to read better the text, so users have no problem. Shouln't the minimum recomended be bigger than 1.15? I always find as typography lover less than 1.25 to small.

Also recently read [Webfont Handbook](https://abookapart.com/products/webfont-handbook), [On Web Typography](https://abookapart.com/products/on-web-typography), [Flexible Typesetting](https://abookapart.com/products/flexible-typesetting) and [Better Web Type](https://betterwebtype.com/) and they recommend bigger line-height.