### PR TITLE
Remove the inheritance of word-wrap for select in Safari

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -189,6 +189,13 @@ select { /* 1 */
 }
 
 /**
+ * Remove the inheritance of word-wrap in Safari.
+ */
+select {
+  word-wrap: normal;
+}
+
+/**
  * Correct the inability to style clickable types in iOS and Safari.
  */
 


### PR DESCRIPTION
When a `<select>` is themed, the `word-wrap` property is inherited in Safari. See 
 https://codepen.io/MartijnCuppens/pen/mamqbe.