### PR TITLE
Combine `pre` and `code,kbd,sample` declarations

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -56,16 +56,6 @@ hr {
   overflow: visible; /* 2 */
 }
 
-/**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
- */
-
-pre {
-  font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
-}
-
 /* Text-level semantics
    ========================================================================== */
 
@@ -102,6 +92,7 @@ strong {
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 
+pre,
 code,
 kbd,
 samp {


### PR DESCRIPTION
why: Because two declaration have same properties. We don't need to
         define them twice.

issue: close #772