### PR TITLE
Don't make inputs have `overflow:visible`

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -170,11 +170,9 @@ textarea {
 
 /**
  * Show the overflow in IE.
- * 1. Show the overflow in Edge.
  */
 
-button,
-input { /* 1 */
+button {
   overflow: visible;
 }
 


### PR DESCRIPTION
This addresses #779 -- as noted there, `overflow:visible` has no effect on most input types in most browsers (and has zero effect in Chrome/Safari).  To the extent that it has effects, it only serves to drive browsers away from a consensus rendering, rather than bringing them closer to a consensus.