### PR TITLE
chore(Comments): Mark license comment as unimportant

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -1,4 +1,4 @@
-/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+/* normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
    ========================================================================== */


### PR DESCRIPTION
@necolas Based on the way this comment is written, it will not be removed by default by a lot of CSS optimizers. Considering how widespread this project is and the fact that this project is MIT licensed I don't believe there is any reason why it should be preserved after minimization. 