### PR TITLE
Simplify legend element normalization

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -240,10 +240,8 @@ fieldset {
 legend {
   box-sizing: border-box; /* 1 */
   color: inherit; /* 2 */
-  display: table; /* 1 */
   max-width: 100%; /* 1 */
   padding: 0; /* 3 */
-  white-space: normal; /* 1 */
 }
 
 /**


### PR DESCRIPTION
See https://github.com/necolas/normalize.css/issues/100#issuecomment-197119273 and https://github.com/necolas/normalize.css/pull/536 . These two declarations are intended to fix IE8, which normalize.css dropped support long ago.