### PR TITLE
Remove outline of anchor tag when got focused on Firefox for Ubuntu

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -70,11 +70,13 @@ pre {
    ========================================================================== */
 
 /**
- * Remove the gray background on active links in IE 10.
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove outline when got focused using Firefox on Linux.
  */
 
 a {
-  background-color: transparent;
+  background-color: transparent; /* 1 */
+  outline: 0; /* 2 */  
 }
 
 /**


### PR DESCRIPTION
Issue #800 

- I added `outline: 0` to fix it
- 1 file changed `normalize.css`

See my [Codepen Example](https://codepen.io/milbeeen/pen/eYYRgdM)