### PR TITLE
revert the removal of SVG overflow:hidden, still needed for IE

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -149,6 +149,14 @@ img {
   border-style: none;
 }
 
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
 /* Forms
    ========================================================================== */
 


### PR DESCRIPTION
The overflow: hidden rule for SVG images was removed in this commit
https://github.com/necolas/normalize.css/commit/004d58b2f2e0ac3d03d075f8de46ce7c8234742
The comment for this commit states:
>   Drop support for older browsers: IE 9-, Android 4, Safari 7-.

This rule is still necessary for supported versions of IE (10/11), so it shouldn't have been removed. This PR brings it back. 