### PR TITLE
Fix typo in normalize.css

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -62,7 +62,7 @@ hr {
  */
 
 pre {
-  font-family: monospace, monospace; /* 1 */
+  font-family: monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 
@@ -105,7 +105,7 @@ strong {
 code,
 kbd,
 samp {
-  font-family: monospace, monospace; /* 1 */
+  font-family: monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 


### PR DESCRIPTION
Remove duplicate font family
```css
font-family: monospace, monospace;
```