### PR TITLE
HR: no need for Firefox normalization

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -46,14 +46,11 @@ h1 {
    ========================================================================== */
 
 /**
- * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
+ * 1. Show the overflow in Edge and IE.
  */
 
 hr {
-  box-sizing: content-box; /* 1 */
-  height: 0; /* 1 */
-  overflow: visible; /* 2 */
+  overflow: visible; /* 1 */
 }
 
 /**


### PR DESCRIPTION
Firefox no longer needs ``box-sizing`` and ``height`` rules, as the browser's stylesheet now specifies the correct ``box-sizing`` value and does not affect height. Tested in Firefox ESR (v. 68) through Firefox Developer Edition (v. 76).

Paste this into Firefox's address bar to view the browser's default styles: ``view-source:resource://gre-resources/html.css``