### PR TITLE
Fix the input[type="search"] documentation block

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,10 @@ decrement button to change from `default` to `text`.
 
 #### `[type="search"]`
 
-The search input is not fully stylable by default. In Chrome and Safari on
-OSX/iOS you can't control `font`, `padding`, `border`, or `background`. In
-Chrome and Safari on Windows you can't control `border` properly. It will apply
-`border-width` but will only show a border color (which cannot be controlled)
-for the outer 1px of that border. Applying `-webkit-appearance: textfield`
-addresses these issues without removing the benefits of search inputs (e.g.
-showing past searches).
+The search input is not fully stylable by default. In Safari on
+OSX you can't control `font`, `padding`, `border`, or `background`. Applying
+`-webkit-appearance: textfield` addresses these issues without removing the
+benefits of search inputs (e.g. showing past searches).
 
 ## Contributing
 

--- a/normalize.css
+++ b/normalize.css
@@ -283,7 +283,7 @@ textarea {
 }
 
 /**
- * 1. Correct the odd appearance in Chrome and Safari.
+ * 1. Correct the odd appearance in Safari.
  * 2. Correct the outline style in Safari.
  */
 

--- a/test.html
+++ b/test.html
@@ -431,7 +431,7 @@
   <h2 class="Test-describe"><code>[type="search"]</code></h2>
   <h3 class="Test-it">should be styleable</h3>
   <div class="Test-run">
-    <input type="search" style="border:1px solid #ADD8E6; padding:10px; width:200px;">
+    <input type="search" style="border:4px dashed #ADD8E6; padding:10px; width:200px; font-family:monospace; background-color:#f0f8ff" value="search query">
   </div>
   <h3 class="Test-it">should reference inherited color</h3>
   <div class="Test-run">


### PR DESCRIPTION
Changes in README.md:
1. Remove notes about Chrome on macOS and Windows, because it's not
reproduced. See attached images. Tested on macOS 10.15 and Windows 10/7.
2. Remove notes about Safari on Windows, because it's completely
out-of-date and not supported anymore by normalize.css. Safari 5.1.7
was the last version supported by Windows XP/Vista/7.
[Safari version history](https://en.wikipedia.org/wiki/Safari_version_history#Windows)

Changes below are required to cover all cases mentioned on README.md for
Safari.

Changes in test.html:
1. Add some new styles:
    - font-family
    - background-color
2. Add the value attribute

Changes in normalize.css:
1. Fix comment about `-webkit-appearance` for Chrome

<img width="1767" alt="Screen Shot 2020-09-06 at 3 16 05 pm" src="https://user-images.githubusercontent.com/33809585/92326949-9d027f00-f05e-11ea-8848-76d88c536597.png">

<img width="1767" alt="Screen Shot 2020-09-06 at 3 24 29 pm" src="https://user-images.githubusercontent.com/33809585/92326953-a5f35080-f05e-11ea-8954-3d194bbc1eb3.png">