### PR TITLE
fix input shrink

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -179,6 +179,14 @@ input { /* 1 */
 }
 
 /**
+ * Normalizes firefox and edge approach of input shrinking to chrome behaviour
+ */
+input {
+  min-width: 0;
+  min-height: 0;
+}
+
+/**
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
  * 1. Remove the inheritance of text transform in Firefox.
  */


### PR DESCRIPTION
Normalize input shrinking inside a flex box as stated here https://github.com/philipwalton/flexbugs/issues/152. It seems that firefox and edge disagree with chrome about how input default shrinking should work.