### PR TITLE
Remove redundant text-transform for FF's select

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -179,12 +179,10 @@ input { /* 1 */
 }
 
 /**
- * Remove the inheritance of text transform in Edge, Firefox, and IE.
- * 1. Remove the inheritance of text transform in Firefox.
+ * Remove the inheritance of text transform in Edge, IE11, and IE10.
  */
 
-button,
-select { /* 1 */
+button {
   text-transform: none;
 }
 

--- a/test.html
+++ b/test.html
@@ -314,7 +314,6 @@
   <h3 class="Test-it">should not inherit <code>text-transform</code></h3>
   <div class="Test-run" style="text-transform:uppercase">
     <button>button</button>
-    <select><option>option</option></select>
   </div>
 
   <h2 class="Test-describe"><code>button</code> and button-style <code>input</code></h2>


### PR DESCRIPTION
Nowadays we don't need to specify the text-transform property for the
select element for Firefox. Such functionality already built-in in
Firefox as well as for all other browsers normalise.css supports:
Chrome, Safari, Edge, IE11, IE10.

Sources:
- [Firefox's forms.css](https://dxr.mozilla.org/mozilla-central/source/layout/style/res/forms.css#133)
- `view-source:resource://gre-resources/forms.css`

Other changes:
- Specify IE supported versions because we still need to set
text-transform for button in Edge, IE11, and IE10 explicitly.
- Remove select from the text-transform UI test

Tested on:
- Safari 13.1.2
- Chrome 85.0.4183.102
- Firefox 80.0.1
- Edge 44.19041.423.0
- IE 11.450.19041.0
- IE 10.0.9200.16384