### PR TITLE
Change the comment about fieldset for Firefox

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -223,7 +223,7 @@ button:-moz-focusring,
 }
 
 /**
- * Correct the padding in Firefox.
+ * Correct the padding in IE11 and IE10.
  */
 
 fieldset {


### PR DESCRIPTION
Specifying the padding property for the fieldset element for Firefox is
not necessary anymore. However, it is required for IE10 and IE11.