### PR TITLE
Fix the comment about the details element in FF

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -314,7 +314,7 @@ textarea {
    ========================================================================== */
 
 /*
- * Add the correct display in Edge, IE 10+, and Firefox.
+ * Add the correct display in Edge, and IE 10+.
  */
 
 details {


### PR DESCRIPTION
Specifying `display: block` is redundant for Firefox nowadays. It's
already implemented in User-Agent Stylesheet in Firefox.

https://dxr.mozilla.org/mozilla-central/source/layout/style/res/html.css#119

<img width="1767" alt="Screen Shot 2020-09-17 at 12 46 49 am" src="https://user-images.githubusercontent.com/33809585/93397067-75db5700-f881-11ea-81de-63b1f4feaec2.png">