### PR TITLE
::-moz-focus-inner: remove unnecessary specificity

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -203,23 +203,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 
-button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
- * Restore the focus styles unset by the previous rule.
- */
-
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
+::-moz-focus-inner {
+	border: 0;
+	padding: 0;
 }
 
 /**


### PR DESCRIPTION
Updated to use the same specificity as in Mozilla's user agent stylesheet (``resource://gre-resources/forms.css``)

Also, this ``::-moz-focus-inner`` rule has no effect on the primary focus style of buttons, so we don't have to "restore" focus styles with a ``:-moz-focusring`` rule.

``:-moz-focusring`` styles are set in ``resource://gre-resources/html.css``

Reduced test case: https://codepen.io/mattbrundage/pen/LYZKNYJ