### PR TITLE
Fieldsets have common attribute and size is widen than I think..

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -228,6 +228,7 @@ button:-moz-focusring,
 
 fieldset {
   padding: 0.35em 0.75em 0.625em;
+  min-inline-size:auto;
 }
 
 /**


### PR DESCRIPTION
I had in trouble with code without attribute 'min-inline-size:auto'.. 
Because many attributes have min-inline-size..
Especially, fieldsets have that size, and I can't make this element to 'width: 100%'.

