### PR TITLE
fix: remove redundant font-family

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -62,7 +62,7 @@ hr {
  */
 
 pre {
-  font-family: monospace, monospace; /* 1 */
+  font-family: monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 


### PR DESCRIPTION
I think the 'monospace' font-family of tag 'pre' is redundant