### PR TITLE
Remove default border-radius from Edge

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -155,6 +155,7 @@ img {
 /**
  * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
+ * 3. Remove border-radius in Edge.
  */
 
 button,
@@ -166,6 +167,7 @@ textarea {
   font-size: 100%; /* 1 */
   line-height: 1.15; /* 1 */
   margin: 0; /* 2 */
+  border-radius: 0; /* 3 */
 }
 
 /**


### PR DESCRIPTION
In Microsoft Edge input elements and buttons have a default border-radius of 2px.
This PR will remove this border-radius to bring the styles in line and normalize them.