### PR TITLE
fix: Remove blue on button, select on iOS 15+ Safari

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -181,11 +181,13 @@ input { /* 1 */
 /**
  * Remove the inheritance of text transform in Edge, Firefox, and IE.
  * 1. Remove the inheritance of text transform in Firefox.
+ * 2. Remove blue color in iOS 15+ Safari
  */
 
 button,
-select { /* 1 */
-  text-transform: none;
+select {
+  color: inherit; /* 2 */
+  text-transform: none; /* 1 */
 }
 
 /**


### PR DESCRIPTION
Hey 👋 

On iOS 15+ devices the button text color has changed to blue (via a user-agent style `color: -apple-system-blue;`).

This is a change from iOS 14- devices which displayed black. While all browsers display buttons slightly differently I felt the blue change was significant enough to warrant a reset as developers might not be expecting this. But I'm also not sure if this is too opinionated for normalize or not, what do you think?

I've put below screenshots of the browsers I have to hand to test on but theres a few key ones missing like IE. 

This is my first contribution, I've checked the contributing guidelines and I think I've got everything correct but if theres anything at all let me know 👍 

Thanks! 💛 

Browser (OS) | Before | After
------------- | --------- | ---------
Safari (iOS 15) | <img width="300" alt="Screenshot 2021-11-08 at 13 24 03" src="https://user-images.githubusercontent.com/846587/140752062-0cb6c612-79b0-4620-962d-80573d9296db.png"> | <img width="300" alt="Screenshot 2021-11-08 at 13 24 17" src="https://user-images.githubusercontent.com/846587/140752181-c1414c3f-4314-4ad0-9b9b-a2a559c2276d.png">
Safari (iOS 13) | <img width="299" alt="Screenshot 2021-11-08 at 13 44 05" src="https://user-images.githubusercontent.com/846587/140752659-808312e2-950b-4c06-a1c7-ae8af535a9b1.png"> | <img width="301" alt="Screenshot 2021-11-08 at 13 44 21" src="https://user-images.githubusercontent.com/846587/140752667-1ca0b31c-79e0-45fe-a853-d5a9e3f1cb65.png">
Chrome 91.0.4472.114 (Android 12) | <img width="449" alt="Screenshot 2021-11-08 at 13 52 06" src="https://user-images.githubusercontent.com/846587/140753922-151fed69-1cca-4274-b574-b2c5b8eb8a0a.png"> | <img width="449" alt="Screenshot 2021-11-08 at 13 52 17" src="https://user-images.githubusercontent.com/846587/140753937-6965a92c-29e0-4d73-8269-a4b8f0f2f419.png">
Safari 15.1 (Mac 11.6.1) | <img width="419" alt="Screenshot 2021-11-08 at 13 48 22" src="https://user-images.githubusercontent.com/846587/140753258-6f4776f9-fd38-415d-a928-0d4b4ab7065e.png"> | <img width="427" alt="Screenshot 2021-11-08 at 13 48 29" src="https://user-images.githubusercontent.com/846587/140753270-17306c6c-0c07-4b23-b5dc-f429ba3b8a71.png">
Chrome 95.0.4638.69 (Mac 11.6.1) | <img width="398" alt="Screenshot 2021-11-08 at 13 47 06" src="https://user-images.githubusercontent.com/846587/140753082-70dedca6-a01e-4b8b-999a-da1456de03cc.png"> | <img width="416" alt="Screenshot 2021-11-08 at 13 47 23" src="https://user-images.githubusercontent.com/846587/140753112-76500136-ddf7-4e7c-902e-9466b7a95f92.png">
Firefox 94.0.1 (Mac 11.6.1) | <img width="464" alt="Screenshot 2021-11-08 at 13 49 32" src="https://user-images.githubusercontent.com/846587/140753447-cb6c3aaa-d6e0-432b-bc8e-8e73605e5be2.png"> | <img width="438" alt="Screenshot 2021-11-08 at 13 49 43" src="https://user-images.githubusercontent.com/846587/140753476-46528431-d042-4034-ae5c-22441ef770d4.png">
