### PR TITLE
[type="search"] "X" removal

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -300,6 +300,26 @@ textarea {
   -webkit-appearance: none;
 }
 
+/* clears the 'X' from Internet Explorer */
+input[type="search"]::-ms-clear {
+  display: none;
+  width: 0;
+  height: 0;
+}
+input[type="search"]::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+/* clears the 'X' from Chrome */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  display: none;
+}
+
 /**
  * 1. Correct the inability to style clickable types in iOS and Safari.
  * 2. Change font properties to `inherit` in Safari.


### PR DESCRIPTION
The existing styling for [type="search"] is not sufficient to clear the X on Chrome and IE. Added CSS to fix that.