### PR TITLE
feature: If `hidden="until-found"`, it's not `display: none`.

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -342,8 +342,9 @@ template {
 
 /**
  * Add the correct display in IE 10.
+ * Except `hidden="until-found"`　because `content-visibility: hidden` is applied.
  */
 
-[hidden] {
+[hidden]:not([hidden="until-found"]) {
   display: none;
 }

--- a/normalize.css
+++ b/normalize.css
@@ -345,6 +345,10 @@ template {
  * Except `hidden="until-found"`　because `content-visibility: hidden` is applied.
  */
 
-[hidden]:not([hidden="until-found"]) {
+[hidden] {
   display: none;
+}
+
+[hidden="until-found"] {
+  display: revert;
 }

--- a/test.html
+++ b/test.html
@@ -142,6 +142,7 @@
       <content></content>
     </template>
     <p hidden>This should be hidden</p>
+    <p hidden="until-found">This is not display none</p>
   </div>
 
   <h2 class="Test-describe"><code>a</code></h2>


### PR DESCRIPTION
`hidden` attribute, which used to have only a boolean value, now also has a new `until-found` value.

ref: https://github.com/whatwg/html/commit/f5def65bda4d01a6a1e105fcf13fe45201b4f48a

Elements with `hidden="until-found"` will have `content-visibility: hidden` applied instead of `display: none`.
If specified with `display: none`, it may not be found in in-page searches.

ref: [HTML の hidden 属性が列挙型に変更され hidden="until-found" が追加](https://blog.w0s.jp/664)

To avoid this problem, the style specification for `hidden` case has been modified.

sample: https://codepen.io/yamanoku/pen/YzYpoqG