### PR TITLE
Default list style position to "outside"

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -347,3 +347,11 @@ template {
 [hidden] {
   display: none;
 }
+
+/**
+ * Default list style to "outside" in Chrome
+ */
+
+li {
+  list-style-position: outside;
+}


### PR DESCRIPTION
As per MDN list-style-position should default to outside, but after some testing, every Chromium based browser defaults this to inside. In IE 11 and Firefox 101, it defaults to outside, as it should.

**Edit:** Safari apparently also defaults this to inside. This quirk is [mentioned in MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position) right before the "Syntax" section on the page.