### PR TITLE
correct summary styling

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -325,7 +325,7 @@ details {
  * Add the correct display in all browsers.
  */
 
-summary {
+details > summary:first-of-type {
   display: list-item;
 }
 


### PR DESCRIPTION
closes #891

This revised style ensures that only summary elements that are properly used will be provided the `display: list-item` style.