### PR TITLE
Etiqueta table

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -347,3 +347,9 @@ template {
 [hidden] {
   display: none;
 }
+/**
+* Remueve un espacio en la parte superior interna de la tabla
+*/
+table {
+   border-collapse: collapse;
+  }


### PR DESCRIPTION
![border-collapse](https://github.com/necolas/normalize.css/assets/157082092/3227f5f0-02a5-4e21-94a7-7ef876d1e787)
Al setear "border-collapse: collapse" se elimina un espacio en blanco que altera la altura de la tabla, como se muestra en la imagen que comparto.
